### PR TITLE
feat: implement DbContext with multi-provider support (#14)

### DIFF
--- a/src/HotBox.Application/Program.cs
+++ b/src/HotBox.Application/Program.cs
@@ -1,7 +1,10 @@
+using HotBox.Infrastructure;
+
 var builder = WebApplication.CreateBuilder(args);
 
 // Add services to the container.
-// Learn more about configuring Swagger/OpenAPI at https://aka.ms/aspnetcore/swashbuckle
+builder.Services.AddInfrastructure(builder.Configuration);
+
 builder.Services.AddEndpointsApiExplorer();
 builder.Services.AddSwaggerGen();
 
@@ -16,29 +19,4 @@ if (app.Environment.IsDevelopment())
 
 app.UseHttpsRedirection();
 
-var summaries = new[]
-{
-    "Freezing", "Bracing", "Chilly", "Cool", "Mild", "Warm", "Balmy", "Hot", "Sweltering", "Scorching"
-};
-
-app.MapGet("/weatherforecast", () =>
-{
-    var forecast =  Enumerable.Range(1, 5).Select(index =>
-        new WeatherForecast
-        (
-            DateOnly.FromDateTime(DateTime.Now.AddDays(index)),
-            Random.Shared.Next(-20, 55),
-            summaries[Random.Shared.Next(summaries.Length)]
-        ))
-        .ToArray();
-    return forecast;
-})
-.WithName("GetWeatherForecast")
-.WithOpenApi();
-
 app.Run();
-
-record WeatherForecast(DateOnly Date, int TemperatureC, string? Summary)
-{
-    public int TemperatureF => 32 + (int)(TemperatureC / 0.5556);
-}

--- a/src/HotBox.Application/appsettings.json
+++ b/src/HotBox.Application/appsettings.json
@@ -5,5 +5,9 @@
       "Microsoft.AspNetCore": "Warning"
     }
   },
-  "AllowedHosts": "*"
+  "AllowedHosts": "*",
+  "Database": {
+    "Provider": "sqlite",
+    "ConnectionString": "Data Source=hotbox.db"
+  }
 }

--- a/src/HotBox.Infrastructure/Class1.cs
+++ b/src/HotBox.Infrastructure/Class1.cs
@@ -1,6 +1,0 @@
-﻿namespace HotBox.Infrastructure;
-
-public class Class1
-{
-
-}

--- a/src/HotBox.Infrastructure/Data/Configurations/AppUserConfiguration.cs
+++ b/src/HotBox.Infrastructure/Data/Configurations/AppUserConfiguration.cs
@@ -1,0 +1,44 @@
+using HotBox.Core.Entities;
+using HotBox.Core.Enums;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
+
+namespace HotBox.Infrastructure.Data.Configurations;
+
+public class AppUserConfiguration : IEntityTypeConfiguration<AppUser>
+{
+    public void Configure(EntityTypeBuilder<AppUser> builder)
+    {
+        builder.Property(u => u.DisplayName)
+            .IsRequired()
+            .HasMaxLength(100);
+
+        builder.Property(u => u.AvatarUrl)
+            .HasMaxLength(500);
+
+        builder.Property(u => u.Status)
+            .IsRequired()
+            .HasConversion<string>();
+
+        builder.Property(u => u.LastSeenUtc)
+            .IsRequired();
+
+        builder.Property(u => u.CreatedAtUtc)
+            .IsRequired();
+
+        builder.HasMany(u => u.Messages)
+            .WithOne(m => m.Author)
+            .HasForeignKey(m => m.AuthorId)
+            .OnDelete(DeleteBehavior.Restrict);
+
+        builder.HasMany(u => u.SentDirectMessages)
+            .WithOne(dm => dm.Sender)
+            .HasForeignKey(dm => dm.SenderId)
+            .OnDelete(DeleteBehavior.Restrict);
+
+        builder.HasMany(u => u.ReceivedDirectMessages)
+            .WithOne(dm => dm.Recipient)
+            .HasForeignKey(dm => dm.RecipientId)
+            .OnDelete(DeleteBehavior.Restrict);
+    }
+}

--- a/src/HotBox.Infrastructure/Data/Configurations/ChannelConfiguration.cs
+++ b/src/HotBox.Infrastructure/Data/Configurations/ChannelConfiguration.cs
@@ -1,0 +1,49 @@
+using HotBox.Core.Entities;
+using HotBox.Core.Enums;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
+
+namespace HotBox.Infrastructure.Data.Configurations;
+
+public class ChannelConfiguration : IEntityTypeConfiguration<Channel>
+{
+    public void Configure(EntityTypeBuilder<Channel> builder)
+    {
+        builder.HasKey(c => c.Id);
+
+        builder.Property(c => c.Id)
+            .ValueGeneratedOnAdd();
+
+        builder.Property(c => c.Name)
+            .IsRequired()
+            .HasMaxLength(100);
+
+        builder.Property(c => c.Topic)
+            .HasMaxLength(500);
+
+        builder.Property(c => c.Type)
+            .IsRequired()
+            .HasConversion<string>();
+
+        builder.Property(c => c.SortOrder)
+            .IsRequired();
+
+        builder.Property(c => c.CreatedAtUtc)
+            .IsRequired();
+
+        builder.Property(c => c.CreatedByUserId)
+            .IsRequired();
+
+        builder.HasOne(c => c.CreatedBy)
+            .WithMany()
+            .HasForeignKey(c => c.CreatedByUserId)
+            .OnDelete(DeleteBehavior.Restrict);
+
+        builder.HasMany(c => c.Messages)
+            .WithOne(m => m.Channel)
+            .HasForeignKey(m => m.ChannelId)
+            .OnDelete(DeleteBehavior.Cascade);
+
+        builder.HasIndex(c => c.CreatedByUserId);
+    }
+}

--- a/src/HotBox.Infrastructure/Data/Configurations/DirectMessageConfiguration.cs
+++ b/src/HotBox.Infrastructure/Data/Configurations/DirectMessageConfiguration.cs
@@ -1,0 +1,42 @@
+using HotBox.Core.Entities;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
+
+namespace HotBox.Infrastructure.Data.Configurations;
+
+public class DirectMessageConfiguration : IEntityTypeConfiguration<DirectMessage>
+{
+    public void Configure(EntityTypeBuilder<DirectMessage> builder)
+    {
+        builder.HasKey(dm => dm.Id);
+
+        builder.Property(dm => dm.Id)
+            .ValueGeneratedOnAdd();
+
+        builder.Property(dm => dm.Content)
+            .IsRequired()
+            .HasMaxLength(4000);
+
+        builder.Property(dm => dm.SenderId)
+            .IsRequired();
+
+        builder.Property(dm => dm.RecipientId)
+            .IsRequired();
+
+        builder.Property(dm => dm.CreatedAtUtc)
+            .IsRequired();
+
+        builder.HasOne(dm => dm.Sender)
+            .WithMany(u => u.SentDirectMessages)
+            .HasForeignKey(dm => dm.SenderId)
+            .OnDelete(DeleteBehavior.Restrict);
+
+        builder.HasOne(dm => dm.Recipient)
+            .WithMany(u => u.ReceivedDirectMessages)
+            .HasForeignKey(dm => dm.RecipientId)
+            .OnDelete(DeleteBehavior.Restrict);
+
+        builder.HasIndex(dm => new { dm.SenderId, dm.CreatedAtUtc });
+        builder.HasIndex(dm => new { dm.RecipientId, dm.CreatedAtUtc });
+    }
+}

--- a/src/HotBox.Infrastructure/Data/Configurations/InviteConfiguration.cs
+++ b/src/HotBox.Infrastructure/Data/Configurations/InviteConfiguration.cs
@@ -1,0 +1,40 @@
+using HotBox.Core.Entities;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
+
+namespace HotBox.Infrastructure.Data.Configurations;
+
+public class InviteConfiguration : IEntityTypeConfiguration<Invite>
+{
+    public void Configure(EntityTypeBuilder<Invite> builder)
+    {
+        builder.HasKey(i => i.Id);
+
+        builder.Property(i => i.Id)
+            .ValueGeneratedOnAdd();
+
+        builder.Property(i => i.Code)
+            .IsRequired()
+            .HasMaxLength(50);
+
+        builder.Property(i => i.CreatedByUserId)
+            .IsRequired();
+
+        builder.Property(i => i.CreatedAtUtc)
+            .IsRequired();
+
+        builder.Property(i => i.UseCount)
+            .IsRequired();
+
+        builder.Property(i => i.IsRevoked)
+            .IsRequired();
+
+        builder.HasOne(i => i.CreatedBy)
+            .WithMany()
+            .HasForeignKey(i => i.CreatedByUserId)
+            .OnDelete(DeleteBehavior.Restrict);
+
+        builder.HasIndex(i => i.Code).IsUnique();
+        builder.HasIndex(i => i.CreatedByUserId);
+    }
+}

--- a/src/HotBox.Infrastructure/Data/Configurations/MessageConfiguration.cs
+++ b/src/HotBox.Infrastructure/Data/Configurations/MessageConfiguration.cs
@@ -1,0 +1,42 @@
+using HotBox.Core.Entities;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
+
+namespace HotBox.Infrastructure.Data.Configurations;
+
+public class MessageConfiguration : IEntityTypeConfiguration<Message>
+{
+    public void Configure(EntityTypeBuilder<Message> builder)
+    {
+        builder.HasKey(m => m.Id);
+
+        builder.Property(m => m.Id)
+            .ValueGeneratedOnAdd();
+
+        builder.Property(m => m.Content)
+            .IsRequired()
+            .HasMaxLength(4000);
+
+        builder.Property(m => m.ChannelId)
+            .IsRequired();
+
+        builder.Property(m => m.AuthorId)
+            .IsRequired();
+
+        builder.Property(m => m.CreatedAtUtc)
+            .IsRequired();
+
+        builder.HasOne(m => m.Channel)
+            .WithMany(c => c.Messages)
+            .HasForeignKey(m => m.ChannelId)
+            .OnDelete(DeleteBehavior.Cascade);
+
+        builder.HasOne(m => m.Author)
+            .WithMany(u => u.Messages)
+            .HasForeignKey(m => m.AuthorId)
+            .OnDelete(DeleteBehavior.Restrict);
+
+        builder.HasIndex(m => new { m.ChannelId, m.CreatedAtUtc });
+        builder.HasIndex(m => m.AuthorId);
+    }
+}

--- a/src/HotBox.Infrastructure/Data/HotBoxDbContext.cs
+++ b/src/HotBox.Infrastructure/Data/HotBoxDbContext.cs
@@ -1,0 +1,29 @@
+using System.Reflection;
+using HotBox.Core.Entities;
+using Microsoft.AspNetCore.Identity;
+using Microsoft.AspNetCore.Identity.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore;
+
+namespace HotBox.Infrastructure.Data;
+
+public class HotBoxDbContext : IdentityDbContext<AppUser, IdentityRole<Guid>, Guid>
+{
+    public HotBoxDbContext(DbContextOptions<HotBoxDbContext> options) : base(options)
+    {
+    }
+
+    public DbSet<Channel> Channels => Set<Channel>();
+
+    public DbSet<Message> Messages => Set<Message>();
+
+    public DbSet<DirectMessage> DirectMessages => Set<DirectMessage>();
+
+    public DbSet<Invite> Invites => Set<Invite>();
+
+    protected override void OnModelCreating(ModelBuilder builder)
+    {
+        base.OnModelCreating(builder);
+
+        builder.ApplyConfigurationsFromAssembly(Assembly.GetExecutingAssembly());
+    }
+}

--- a/src/HotBox.Infrastructure/DependencyInjection.cs
+++ b/src/HotBox.Infrastructure/DependencyInjection.cs
@@ -1,0 +1,50 @@
+using HotBox.Infrastructure.Data;
+using HotBox.Infrastructure.Options;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace HotBox.Infrastructure;
+
+public static class DependencyInjection
+{
+    public static IServiceCollection AddInfrastructure(
+        this IServiceCollection services,
+        IConfiguration configuration)
+    {
+        var dbOptions = configuration
+            .GetSection(DatabaseOptions.SectionName)
+            .Get<DatabaseOptions>()
+            ?? throw new InvalidOperationException($"Missing {DatabaseOptions.SectionName} configuration section");
+
+        if (string.IsNullOrWhiteSpace(dbOptions.ConnectionString))
+        {
+            throw new InvalidOperationException("Database:ConnectionString is required");
+        }
+
+        services.AddDbContext<HotBoxDbContext>(options =>
+        {
+            switch (dbOptions.Provider.ToLowerInvariant())
+            {
+                case "sqlite":
+                    options.UseSqlite(dbOptions.ConnectionString);
+                    break;
+                case "postgresql":
+                case "postgres":
+                    options.UseNpgsql(dbOptions.ConnectionString);
+                    break;
+                case "mysql":
+                case "mariadb":
+                    options.UseMySql(
+                        dbOptions.ConnectionString,
+                        ServerVersion.AutoDetect(dbOptions.ConnectionString));
+                    break;
+                default:
+                    throw new InvalidOperationException(
+                        $"Unsupported database provider: {dbOptions.Provider}");
+            }
+        });
+
+        return services;
+    }
+}

--- a/src/HotBox.Infrastructure/HotBox.Infrastructure.csproj
+++ b/src/HotBox.Infrastructure/HotBox.Infrastructure.csproj
@@ -1,13 +1,22 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
-  <ItemGroup>
-    <ProjectReference Include="..\HotBox.Core\HotBox.Core.csproj" />
-  </ItemGroup>
-
   <PropertyGroup>
     <TargetFramework>net8.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
   </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="8.0.11" />
+    <PackageReference Include="Microsoft.AspNetCore.Identity.EntityFrameworkCore" Version="8.0.11" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="8.0.11" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="8.0.*" />
+    <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="8.0.11" />
+    <PackageReference Include="Pomelo.EntityFrameworkCore.MySql" Version="8.0.2" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\HotBox.Core\HotBox.Core.csproj" />
+  </ItemGroup>
 
 </Project>

--- a/src/HotBox.Infrastructure/Options/DatabaseOptions.cs
+++ b/src/HotBox.Infrastructure/Options/DatabaseOptions.cs
@@ -1,0 +1,10 @@
+namespace HotBox.Infrastructure.Options;
+
+public class DatabaseOptions
+{
+    public const string SectionName = "Database";
+
+    public string Provider { get; set; } = "sqlite";
+
+    public string ConnectionString { get; set; } = string.Empty;
+}


### PR DESCRIPTION
## Summary

This PR implements the `HotBoxDbContext` with multi-provider database support (SQLite, PostgreSQL, MySQL/MariaDB) and entity configurations for all Core domain entities.

### Changes

**Created:**
- `HotBoxDbContext` extending `IdentityDbContext<AppUser, IdentityRole<Guid>, Guid>`
- Entity configurations (IEntityTypeConfiguration<T>) for all 5 entities:
  - AppUserConfiguration
  - ChannelConfiguration
  - MessageConfiguration
  - DirectMessageConfiguration
  - InviteConfiguration
- `DatabaseOptions` class for configuration binding
- `DependencyInjection.cs` with `AddInfrastructure(IConfiguration)` extension method
- `appsettings.json` with default SQLite configuration

**Modified:**
- Added EF Core NuGet packages (Core, Identity.EF, Sqlite, Npgsql, Pomelo.MySQL)
- Updated `Program.cs` to call `AddInfrastructure` and removed weather forecast boilerplate

**Deleted:**
- Placeholder `Class1.cs`

### Technical Details

- **Multi-provider support**: Database provider selected via `Database:Provider` config (sqlite/postgresql/mysql)
- **Entity configurations**: All entities have proper string lengths, indexes on FKs, enum-as-string storage, and Restrict delete behavior on user FKs
- **Connection string validation**: DI registration validates connection string presence
- **Indexes**: Created on all FKs plus unique index on `Invite.Code` and index on `Message.AuthorId`

### Review Status

- **Code Review**: APPROVED (after 1 fix iteration resolving 3 critical + 2 major issues)
- **UI Review**: SKIPPED (no UI files)
- **Unresolved items**: none

Closes #14

🤖 Generated with [Claude Code](https://claude.com/claude-code)