### PR TITLE
feat: integrate ASP.NET Identity with AppUser (#21)

### DIFF
--- a/src/HotBox.Application/Program.cs
+++ b/src/HotBox.Application/Program.cs
@@ -42,6 +42,8 @@ try
 
     app.UseHttpsRedirection();
     app.UseCors();
+    app.UseAuthentication();
+    app.UseAuthorization();
     app.MapControllers();
 
     app.Run();

--- a/src/HotBox.Infrastructure/DependencyInjection/InfrastructureServiceExtensions.cs
+++ b/src/HotBox.Infrastructure/DependencyInjection/InfrastructureServiceExtensions.cs
@@ -1,7 +1,9 @@
+using HotBox.Core.Entities;
 using HotBox.Core.Interfaces;
 using HotBox.Core.Options;
 using HotBox.Infrastructure.Data;
 using HotBox.Infrastructure.Repositories;
+using Microsoft.AspNetCore.Identity;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
@@ -55,6 +57,28 @@ public static class InfrastructureServiceExtensions
                         $"Unsupported database provider: {dbOptions.Provider}");
             }
         });
+
+        // Register ASP.NET Identity
+        services.AddIdentity<AppUser, IdentityRole<Guid>>(options =>
+        {
+            // Password policy
+            options.Password.RequireDigit = true;
+            options.Password.RequireLowercase = true;
+            options.Password.RequireUppercase = true;
+            options.Password.RequireNonAlphanumeric = false;
+            options.Password.RequiredLength = 8;
+            options.Password.RequiredUniqueChars = 4;
+
+            // Lockout settings
+            options.Lockout.DefaultLockoutTimeSpan = TimeSpan.FromMinutes(15);
+            options.Lockout.MaxFailedAccessAttempts = 5;
+            options.Lockout.AllowedForNewUsers = true;
+
+            // User settings
+            options.User.RequireUniqueEmail = true;
+        })
+        .AddEntityFrameworkStores<HotBoxDbContext>()
+        .AddDefaultTokenProviders();
 
         // Register repositories
         services.AddScoped<IChannelRepository, ChannelRepository>();

--- a/src/HotBox.Infrastructure/HotBox.Infrastructure.csproj
+++ b/src/HotBox.Infrastructure/HotBox.Infrastructure.csproj
@@ -7,6 +7,7 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <FrameworkReference Include="Microsoft.AspNetCore.App" />
     <PackageReference Include="Microsoft.EntityFrameworkCore" Version="8.0.11" />
     <PackageReference Include="Microsoft.AspNetCore.Identity.EntityFrameworkCore" Version="8.0.11" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="8.0.11" />


### PR DESCRIPTION
## Summary

This PR integrates ASP.NET Identity with the existing `AppUser` entity from Core.

### Changes Made

- **Infrastructure Layer**:
  - Added ASP.NET Identity registration in `InfrastructureServiceExtensions.AddInfrastructure()` with:
    - Password policy: 8+ char minimum, require digit/lowercase/uppercase, no special chars required, 4 unique chars
    - Account lockout: 15 min lockout after 5 failed attempts, enabled for new users
    - User settings: require unique email
    - Entity Framework stores backed by `HotBoxDbContext`
    - Default token providers for password reset, email confirmation, etc.
  - Added `FrameworkReference` to `Microsoft.AspNetCore.App` in Infrastructure csproj (needed for `AddIdentity` API)

- **Application Layer**:
  - Added `UseAuthentication()` and `UseAuthorization()` middleware in Program.cs pipeline (after CORS, before endpoint mapping)

### Files Changed
- `src/HotBox.Infrastructure/DependencyInjection/InfrastructureServiceExtensions.cs`
- `src/HotBox.Infrastructure/HotBox.Infrastructure.csproj`
- `src/HotBox.Application/Program.cs`

Closes #21

🤖 Generated with [Claude Code](https://claude.com/claude-code)