### PR TITLE
feat: implement JWT token generation and refresh token flow (#22, #23)

### DIFF
--- a/src/HotBox.Application/Controllers/AuthController.cs
+++ b/src/HotBox.Application/Controllers/AuthController.cs
@@ -1,0 +1,109 @@
+using HotBox.Core.Interfaces;
+using HotBox.Core.Options;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.Extensions.Options;
+
+namespace HotBox.Application.Controllers;
+
+[ApiController]
+[Route("api/auth")]
+public class AuthController : ControllerBase
+{
+    private readonly ITokenService _tokenService;
+    private readonly JwtOptions _jwtOptions;
+    private readonly ILogger<AuthController> _logger;
+    private readonly IWebHostEnvironment _environment;
+
+    private const string RefreshTokenCookieName = "refreshToken";
+
+    public AuthController(
+        ITokenService tokenService,
+        IOptions<JwtOptions> jwtOptions,
+        ILogger<AuthController> logger,
+        IWebHostEnvironment environment)
+    {
+        _tokenService = tokenService;
+        _jwtOptions = jwtOptions.Value;
+        _logger = logger;
+        _environment = environment;
+    }
+
+    [HttpPost("refresh")]
+    public async Task<IActionResult> Refresh(CancellationToken ct)
+    {
+        var refreshTokenValue = Request.Cookies[RefreshTokenCookieName];
+
+        if (string.IsNullOrWhiteSpace(refreshTokenValue))
+        {
+            _logger.LogWarning("Refresh attempt with missing refresh token cookie");
+            return Unauthorized(new { error = "Refresh token is required." });
+        }
+
+        var existingToken = await _tokenService.ValidateRefreshTokenAsync(refreshTokenValue, ct);
+
+        if (existingToken is null)
+        {
+            _logger.LogWarning("Refresh attempt with invalid or expired refresh token");
+            ClearRefreshTokenCookie();
+            return Unauthorized(new { error = "Invalid or expired refresh token." });
+        }
+
+        // Rotate the refresh token (revokes old, creates new)
+        var newRefreshToken = await _tokenService.RotateRefreshTokenAsync(existingToken, ct);
+
+        // Generate a new access token
+        var accessToken = await _tokenService.GenerateAccessTokenAsync(existingToken.User, ct);
+
+        // Set the new refresh token as an HttpOnly cookie
+        SetRefreshTokenCookie(newRefreshToken.Token, newRefreshToken.ExpiresAtUtc);
+
+        _logger.LogInformation("Token refreshed for user {UserId}", existingToken.UserId);
+
+        return Ok(new { accessToken });
+    }
+
+    [Authorize]
+    [HttpPost("revoke")]
+    public async Task<IActionResult> Revoke(CancellationToken ct)
+    {
+        var refreshTokenValue = Request.Cookies[RefreshTokenCookieName];
+
+        if (string.IsNullOrWhiteSpace(refreshTokenValue))
+        {
+            _logger.LogDebug("Revoke called with no refresh token cookie present");
+            return NoContent();
+        }
+
+        await _tokenService.RevokeRefreshTokenAsync(refreshTokenValue, ct);
+
+        ClearRefreshTokenCookie();
+
+        _logger.LogInformation("Refresh token revoked via logout");
+
+        return NoContent();
+    }
+
+    private void SetRefreshTokenCookie(string token, DateTime expiresAtUtc)
+    {
+        var cookieOptions = new CookieOptions
+        {
+            HttpOnly = true,
+            Secure = !_environment.IsDevelopment(),
+            SameSite = SameSiteMode.Strict,
+            Expires = expiresAtUtc,
+        };
+
+        Response.Cookies.Append(RefreshTokenCookieName, token, cookieOptions);
+    }
+
+    private void ClearRefreshTokenCookie()
+    {
+        Response.Cookies.Delete(RefreshTokenCookieName, new CookieOptions
+        {
+            HttpOnly = true,
+            Secure = !_environment.IsDevelopment(),
+            SameSite = SameSiteMode.Strict,
+        });
+    }
+}

--- a/src/HotBox.Application/DependencyInjection/ApplicationServiceExtensions.cs
+++ b/src/HotBox.Application/DependencyInjection/ApplicationServiceExtensions.cs
@@ -1,6 +1,9 @@
+using System.Text;
 using HotBox.Core.Options;
+using Microsoft.AspNetCore.Authentication.JwtBearer;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.IdentityModel.Tokens;
 
 namespace HotBox.Application.DependencyInjection;
 
@@ -16,7 +19,42 @@ public static class ApplicationServiceExtensions
         services.Configure<IceServerOptions>(configuration.GetSection(IceServerOptions.SectionName));
         services.Configure<AdminSeedOptions>(configuration.GetSection(AdminSeedOptions.SectionName));
 
-        // API controllers (for future use)
+        // JWT Bearer Authentication
+        var jwtOptions = configuration
+            .GetSection(JwtOptions.SectionName)
+            .Get<JwtOptions>()
+            ?? new JwtOptions();
+
+        if (string.IsNullOrWhiteSpace(jwtOptions.Secret) || jwtOptions.Secret.Length < 32)
+        {
+            throw new InvalidOperationException(
+                "Jwt:Secret must be configured and at least 32 characters for HMAC-SHA256");
+        }
+
+        services.AddAuthentication(options =>
+        {
+            options.DefaultAuthenticateScheme = JwtBearerDefaults.AuthenticationScheme;
+            options.DefaultChallengeScheme = JwtBearerDefaults.AuthenticationScheme;
+        })
+        .AddJwtBearer(options =>
+        {
+            options.TokenValidationParameters = new TokenValidationParameters
+            {
+                ValidateIssuer = true,
+                ValidIssuer = jwtOptions.Issuer,
+                ValidateAudience = true,
+                ValidAudience = jwtOptions.Audience,
+                ValidateIssuerSigningKey = true,
+                IssuerSigningKey = new SymmetricSecurityKey(
+                    Encoding.UTF8.GetBytes(jwtOptions.Secret)),
+                ValidateLifetime = true,
+                ClockSkew = TimeSpan.FromSeconds(30),
+            };
+        });
+
+        services.AddAuthorization();
+
+        // API controllers
         services.AddControllers();
 
         // SignalR for real-time hubs

--- a/src/HotBox.Application/HotBox.Application.csproj
+++ b/src/HotBox.Application/HotBox.Application.csproj
@@ -7,6 +7,7 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="8.0.11" />
     <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="8.0.23" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="8.0.11">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/src/HotBox.Application/appsettings.json
+++ b/src/HotBox.Application/appsettings.json
@@ -19,7 +19,7 @@
     "Secret": "",
     "Issuer": "HotBox",
     "Audience": "HotBox",
-    "AccessTokenExpiration": "00:30:00",
+    "AccessTokenExpiration": "00:15:00",
     "RefreshTokenExpiration": "7.00:00:00"
   },
   "OAuth": {

--- a/src/HotBox.Core/Entities/RefreshToken.cs
+++ b/src/HotBox.Core/Entities/RefreshToken.cs
@@ -1,0 +1,26 @@
+namespace HotBox.Core.Entities;
+
+public class RefreshToken
+{
+    public Guid Id { get; init; }
+
+    public string Token { get; set; } = string.Empty;
+
+    public Guid UserId { get; set; }
+
+    public AppUser User { get; set; } = null!;
+
+    public DateTime CreatedAtUtc { get; set; }
+
+    public DateTime ExpiresAtUtc { get; set; }
+
+    public DateTime? RevokedAtUtc { get; set; }
+
+    public string? ReplacedByToken { get; set; }
+
+    public bool IsRevoked => RevokedAtUtc.HasValue;
+
+    public bool IsExpired => DateTime.UtcNow >= ExpiresAtUtc;
+
+    public bool IsActive => !IsRevoked && !IsExpired;
+}

--- a/src/HotBox.Core/Interfaces/ITokenService.cs
+++ b/src/HotBox.Core/Interfaces/ITokenService.cs
@@ -1,0 +1,18 @@
+using HotBox.Core.Entities;
+
+namespace HotBox.Core.Interfaces;
+
+public interface ITokenService
+{
+    Task<string> GenerateAccessTokenAsync(AppUser user, CancellationToken ct = default);
+
+    Task<RefreshToken> GenerateRefreshTokenAsync(Guid userId, CancellationToken ct = default);
+
+    Task<RefreshToken?> ValidateRefreshTokenAsync(string token, CancellationToken ct = default);
+
+    Task<RefreshToken> RotateRefreshTokenAsync(RefreshToken existingToken, CancellationToken ct = default);
+
+    Task RevokeRefreshTokenAsync(string token, CancellationToken ct = default);
+
+    Task RevokeAllUserRefreshTokensAsync(Guid userId, CancellationToken ct = default);
+}

--- a/src/HotBox.Core/Options/JwtOptions.cs
+++ b/src/HotBox.Core/Options/JwtOptions.cs
@@ -10,7 +10,7 @@ public class JwtOptions
 
     public string Audience { get; set; } = "HotBox";
 
-    public TimeSpan AccessTokenExpiration { get; set; } = TimeSpan.FromMinutes(30);
+    public TimeSpan AccessTokenExpiration { get; set; } = TimeSpan.FromMinutes(15);
 
     public TimeSpan RefreshTokenExpiration { get; set; } = TimeSpan.FromDays(7);
 }

--- a/src/HotBox.Infrastructure/Data/Configurations/RefreshTokenConfiguration.cs
+++ b/src/HotBox.Infrastructure/Data/Configurations/RefreshTokenConfiguration.cs
@@ -1,0 +1,44 @@
+using HotBox.Core.Entities;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
+
+namespace HotBox.Infrastructure.Data.Configurations;
+
+public class RefreshTokenConfiguration : IEntityTypeConfiguration<RefreshToken>
+{
+    public void Configure(EntityTypeBuilder<RefreshToken> builder)
+    {
+        builder.HasKey(rt => rt.Id);
+
+        builder.Property(rt => rt.Id)
+            .ValueGeneratedOnAdd();
+
+        builder.Property(rt => rt.Token)
+            .IsRequired()
+            .HasMaxLength(256);
+
+        builder.Property(rt => rt.UserId)
+            .IsRequired();
+
+        builder.Property(rt => rt.CreatedAtUtc)
+            .IsRequired();
+
+        builder.Property(rt => rt.ExpiresAtUtc)
+            .IsRequired();
+
+        builder.Property(rt => rt.ReplacedByToken)
+            .HasMaxLength(256);
+
+        builder.Ignore(rt => rt.IsRevoked);
+        builder.Ignore(rt => rt.IsExpired);
+        builder.Ignore(rt => rt.IsActive);
+
+        builder.HasOne(rt => rt.User)
+            .WithMany()
+            .HasForeignKey(rt => rt.UserId)
+            .OnDelete(DeleteBehavior.Cascade);
+
+        builder.HasIndex(rt => rt.Token).IsUnique();
+        builder.HasIndex(rt => rt.UserId);
+    }
+}

--- a/src/HotBox.Infrastructure/Data/HotBoxDbContext.cs
+++ b/src/HotBox.Infrastructure/Data/HotBoxDbContext.cs
@@ -20,6 +20,8 @@ public class HotBoxDbContext : IdentityDbContext<AppUser, IdentityRole<Guid>, Gu
 
     public DbSet<Invite> Invites => Set<Invite>();
 
+    public DbSet<RefreshToken> RefreshTokens => Set<RefreshToken>();
+
     protected override void OnModelCreating(ModelBuilder builder)
     {
         base.OnModelCreating(builder);

--- a/src/HotBox.Infrastructure/DependencyInjection/InfrastructureServiceExtensions.cs
+++ b/src/HotBox.Infrastructure/DependencyInjection/InfrastructureServiceExtensions.cs
@@ -3,6 +3,7 @@ using HotBox.Core.Interfaces;
 using HotBox.Core.Options;
 using HotBox.Infrastructure.Data;
 using HotBox.Infrastructure.Repositories;
+using HotBox.Infrastructure.Services;
 using Microsoft.AspNetCore.Identity;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Configuration;
@@ -85,6 +86,9 @@ public static class InfrastructureServiceExtensions
         services.AddScoped<IMessageRepository, MessageRepository>();
         services.AddScoped<IDirectMessageRepository, DirectMessageRepository>();
         services.AddScoped<IInviteRepository, InviteRepository>();
+
+        // Register services
+        services.AddScoped<ITokenService, TokenService>();
 
         return services;
     }

--- a/src/HotBox.Infrastructure/HotBox.Infrastructure.csproj
+++ b/src/HotBox.Infrastructure/HotBox.Infrastructure.csproj
@@ -12,6 +12,7 @@
     <PackageReference Include="Microsoft.AspNetCore.Identity.EntityFrameworkCore" Version="8.0.11" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="8.0.11" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="8.0.*" />
+    <PackageReference Include="System.IdentityModel.Tokens.Jwt" Version="8.0.*" />
     <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="8.0.11" />
     <PackageReference Include="Pomelo.EntityFrameworkCore.MySql" Version="8.0.2" />
   </ItemGroup>

--- a/src/HotBox.Infrastructure/Services/TokenService.cs
+++ b/src/HotBox.Infrastructure/Services/TokenService.cs
@@ -1,0 +1,207 @@
+using System.IdentityModel.Tokens.Jwt;
+using System.Security.Claims;
+using System.Security.Cryptography;
+using System.Text;
+using HotBox.Core.Entities;
+using HotBox.Core.Interfaces;
+using HotBox.Core.Options;
+using HotBox.Infrastructure.Data;
+using Microsoft.AspNetCore.Identity;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+using Microsoft.IdentityModel.Tokens;
+
+namespace HotBox.Infrastructure.Services;
+
+public class TokenService : ITokenService
+{
+    private readonly HotBoxDbContext _context;
+    private readonly UserManager<AppUser> _userManager;
+    private readonly JwtOptions _jwtOptions;
+    private readonly ILogger<TokenService> _logger;
+
+    public TokenService(
+        HotBoxDbContext context,
+        UserManager<AppUser> userManager,
+        IOptions<JwtOptions> jwtOptions,
+        ILogger<TokenService> logger)
+    {
+        _context = context;
+        _userManager = userManager;
+        _jwtOptions = jwtOptions.Value;
+        _logger = logger;
+    }
+
+    public async Task<string> GenerateAccessTokenAsync(AppUser user, CancellationToken ct = default)
+    {
+        var roles = await _userManager.GetRolesAsync(user);
+
+        var claims = new List<Claim>
+        {
+            new(JwtRegisteredClaimNames.Sub, user.Id.ToString()),
+            new(JwtRegisteredClaimNames.Email, user.Email ?? string.Empty),
+            new(JwtRegisteredClaimNames.Jti, Guid.NewGuid().ToString()),
+            new("display_name", user.DisplayName),
+        };
+
+        foreach (var role in roles)
+        {
+            claims.Add(new Claim(ClaimTypes.Role, role));
+        }
+
+        var key = new SymmetricSecurityKey(Encoding.UTF8.GetBytes(_jwtOptions.Secret));
+        var credentials = new SigningCredentials(key, SecurityAlgorithms.HmacSha256);
+
+        var token = new JwtSecurityToken(
+            issuer: _jwtOptions.Issuer,
+            audience: _jwtOptions.Audience,
+            claims: claims,
+            expires: DateTime.UtcNow.Add(_jwtOptions.AccessTokenExpiration),
+            signingCredentials: credentials);
+
+        var tokenString = new JwtSecurityTokenHandler().WriteToken(token);
+
+        _logger.LogDebug("Generated access token for user {UserId}", user.Id);
+
+        return tokenString;
+    }
+
+    public async Task<RefreshToken> GenerateRefreshTokenAsync(Guid userId, CancellationToken ct = default)
+    {
+        var tokenValue = GenerateSecureToken();
+
+        var refreshToken = new RefreshToken
+        {
+            Token = tokenValue,
+            UserId = userId,
+            CreatedAtUtc = DateTime.UtcNow,
+            ExpiresAtUtc = DateTime.UtcNow.Add(_jwtOptions.RefreshTokenExpiration),
+        };
+
+        _context.RefreshTokens.Add(refreshToken);
+        await _context.SaveChangesAsync(ct);
+
+        _logger.LogDebug("Generated refresh token for user {UserId}", userId);
+
+        return refreshToken;
+    }
+
+    public async Task<RefreshToken?> ValidateRefreshTokenAsync(string token, CancellationToken ct = default)
+    {
+        var refreshToken = await _context.RefreshTokens
+            .Include(rt => rt.User)
+            .FirstOrDefaultAsync(rt => rt.Token == token, ct);
+
+        if (refreshToken is null)
+        {
+            _logger.LogWarning("Refresh token not found during validation");
+            return null;
+        }
+
+        if (!refreshToken.IsActive)
+        {
+            _logger.LogWarning("Inactive refresh token used for user {UserId}", refreshToken.UserId);
+            return null;
+        }
+
+        return refreshToken;
+    }
+
+    public async Task<RefreshToken> RotateRefreshTokenAsync(RefreshToken existingToken, CancellationToken ct = default)
+    {
+        await using var transaction = await _context.Database
+            .BeginTransactionAsync(System.Data.IsolationLevel.RepeatableRead, ct);
+
+        try
+        {
+            // Re-fetch the token within the transaction to prevent race conditions
+            var tokenToRevoke = await _context.RefreshTokens
+                .FirstOrDefaultAsync(rt => rt.Id == existingToken.Id && rt.RevokedAtUtc == null, ct);
+
+            if (tokenToRevoke is null)
+            {
+                throw new InvalidOperationException("Refresh token has already been revoked.");
+            }
+
+            var newTokenValue = GenerateSecureToken();
+
+            // Revoke the existing token
+            tokenToRevoke.RevokedAtUtc = DateTime.UtcNow;
+            tokenToRevoke.ReplacedByToken = newTokenValue;
+
+            // Create the replacement token
+            var newToken = new RefreshToken
+            {
+                Token = newTokenValue,
+                UserId = tokenToRevoke.UserId,
+                CreatedAtUtc = DateTime.UtcNow,
+                ExpiresAtUtc = DateTime.UtcNow.Add(_jwtOptions.RefreshTokenExpiration),
+            };
+
+            _context.RefreshTokens.Add(newToken);
+            await _context.SaveChangesAsync(ct);
+            await transaction.CommitAsync(ct);
+
+            _logger.LogDebug("Rotated refresh token for user {UserId}", tokenToRevoke.UserId);
+
+            return newToken;
+        }
+        catch (Exception) when (ct.IsCancellationRequested)
+        {
+            throw;
+        }
+        catch (InvalidOperationException)
+        {
+            throw;
+        }
+        catch (Exception ex)
+        {
+            _logger.LogWarning(ex, "Token rotation failed due to concurrent access for user {UserId}", existingToken.UserId);
+            throw new InvalidOperationException("Refresh token has already been revoked.");
+        }
+    }
+
+    public async Task RevokeRefreshTokenAsync(string token, CancellationToken ct = default)
+    {
+        var refreshToken = await _context.RefreshTokens
+            .FirstOrDefaultAsync(rt => rt.Token == token, ct);
+
+        if (refreshToken is null)
+        {
+            _logger.LogWarning("Attempted to revoke a non-existent refresh token");
+            return;
+        }
+
+        if (refreshToken.IsRevoked)
+        {
+            _logger.LogDebug("Refresh token already revoked for user {UserId}", refreshToken.UserId);
+            return;
+        }
+
+        refreshToken.RevokedAtUtc = DateTime.UtcNow;
+        await _context.SaveChangesAsync(ct);
+
+        _logger.LogInformation("Revoked refresh token for user {UserId}", refreshToken.UserId);
+    }
+
+    public async Task RevokeAllUserRefreshTokensAsync(Guid userId, CancellationToken ct = default)
+    {
+        var revokedCount = await _context.RefreshTokens
+            .Where(rt => rt.UserId == userId && rt.RevokedAtUtc == null)
+            .ExecuteUpdateAsync(s => s.SetProperty(rt => rt.RevokedAtUtc, DateTime.UtcNow), ct);
+
+        _logger.LogInformation(
+            "Revoked {TokenCount} refresh tokens for user {UserId}",
+            revokedCount,
+            userId);
+    }
+
+    private static string GenerateSecureToken()
+    {
+        var randomBytes = new byte[64];
+        using var rng = RandomNumberGenerator.Create();
+        rng.GetBytes(randomBytes);
+        return Convert.ToBase64String(randomBytes);
+    }
+}


### PR DESCRIPTION
## Summary

- Add `ITokenService` interface (Core) and `TokenService` implementation (Infrastructure) for JWT access token generation with HMAC-SHA256 signing and claims (UserId, Email, DisplayName, Roles)
- Add `RefreshToken` entity with EF Core configuration, server-side storage, cryptographic token generation, and rotation on use
- Add `AuthController` with `POST /api/auth/refresh` (HttpOnly cookie-based) and `POST /api/auth/revoke` endpoints
- Configure JWT bearer authentication in the DI pipeline with startup validation for JWT secret

## Changes

### Core Layer
- `RefreshToken` entity with computed `IsExpired`/`IsActive`/`IsRevoked` properties
- `ITokenService` interface for token generation, validation, rotation, and revocation
- `JwtOptions.AccessTokenExpiration` default changed from 30 min to 15 min per requirements

### Infrastructure Layer
- `TokenService` with JWT generation, refresh token CRUD, transaction-safe rotation (RepeatableRead isolation), and bulk revocation via `ExecuteUpdateAsync`
- `RefreshTokenConfiguration` with indexes on Token (unique) and UserId
- `DbSet<RefreshToken>` added to `HotBoxDbContext`
- `System.IdentityModel.Tokens.Jwt` NuGet added

### Application Layer
- `AuthController` with refresh and revoke endpoints, environment-aware HttpOnly cookie handling
- JWT bearer authentication configured in `ApplicationServiceExtensions`
- `Microsoft.AspNetCore.Authentication.JwtBearer` NuGet added
- Startup validation: throws if `Jwt:Secret` is missing or < 32 characters

## Follow-up Required
- EF Core migration needed for `RefreshTokens` table before refresh flow is usable
- `Jwt:Secret` must be configured (32+ chars) via user-secrets or environment variable

Closes #22
Closes #23

🤖 Generated with [Claude Code](https://claude.com/claude-code)