### PR TITLE
feat: complete auth system with registration, OAuth, invites, and seeding (#24-#29)

### DIFF
--- a/src/HotBox.Application/Controllers/AuthController.cs
+++ b/src/HotBox.Application/Controllers/AuthController.cs
@@ -1,6 +1,12 @@
+using System.Security.Claims;
+using HotBox.Application.Models;
+using HotBox.Core.Entities;
+using HotBox.Core.Enums;
 using HotBox.Core.Interfaces;
 using HotBox.Core.Options;
+using Microsoft.AspNetCore.Authentication;
 using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Identity;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.Extensions.Options;
 
@@ -12,21 +18,143 @@ public class AuthController : ControllerBase
 {
     private readonly ITokenService _tokenService;
     private readonly JwtOptions _jwtOptions;
+    private readonly ServerOptions _serverOptions;
+    private readonly OAuthOptions _oauthOptions;
+    private readonly UserManager<AppUser> _userManager;
+    private readonly SignInManager<AppUser> _signInManager;
+    private readonly IInviteService _inviteService;
     private readonly ILogger<AuthController> _logger;
     private readonly IWebHostEnvironment _environment;
 
     private const string RefreshTokenCookieName = "refreshToken";
+    private const string DefaultRole = "Member";
+
+    private static readonly HashSet<string> SupportedProviders = new(StringComparer.OrdinalIgnoreCase)
+    {
+        "Google",
+        "Microsoft",
+    };
 
     public AuthController(
         ITokenService tokenService,
         IOptions<JwtOptions> jwtOptions,
+        IOptions<ServerOptions> serverOptions,
+        IOptions<OAuthOptions> oauthOptions,
+        UserManager<AppUser> userManager,
+        SignInManager<AppUser> signInManager,
+        IInviteService inviteService,
         ILogger<AuthController> logger,
         IWebHostEnvironment environment)
     {
         _tokenService = tokenService;
         _jwtOptions = jwtOptions.Value;
+        _serverOptions = serverOptions.Value;
+        _oauthOptions = oauthOptions.Value;
+        _userManager = userManager;
+        _signInManager = signInManager;
+        _inviteService = inviteService;
         _logger = logger;
         _environment = environment;
+    }
+
+    [HttpPost("register")]
+    public async Task<IActionResult> Register([FromBody] RegisterRequest request, CancellationToken ct)
+    {
+        // Enforce registration mode
+        switch (_serverOptions.RegistrationMode)
+        {
+            case RegistrationMode.Closed:
+                _logger.LogWarning("Registration attempt rejected: registration is closed");
+                return StatusCode(403, new { error = "Registration is currently closed." });
+
+            case RegistrationMode.InviteOnly:
+                if (string.IsNullOrWhiteSpace(request.InviteCode))
+                {
+                    _logger.LogWarning("Registration attempt rejected: invite code required but not provided");
+                    return BadRequest(new { error = "An invite code is required to register." });
+                }
+
+                var invite = await _inviteService.ValidateAndConsumeAsync(request.InviteCode, ct);
+                if (invite is null)
+                {
+                    _logger.LogWarning("Registration attempt rejected: invalid or expired invite code");
+                    return BadRequest(new { error = "The invite code is invalid or has expired." });
+                }
+                break;
+
+            case RegistrationMode.Open:
+                break;
+        }
+
+        // Check if a user with this email already exists
+        var existingUser = await _userManager.FindByEmailAsync(request.Email);
+        if (existingUser is not null)
+        {
+            _logger.LogWarning("Registration attempt for existing email {Email}", request.Email);
+            return BadRequest(new { error = "An account with this email already exists." });
+        }
+
+        var user = new AppUser
+        {
+            UserName = request.Email,
+            Email = request.Email,
+            DisplayName = request.DisplayName,
+            Status = UserStatus.Offline,
+            CreatedAtUtc = DateTime.UtcNow,
+            LastSeenUtc = DateTime.UtcNow,
+        };
+
+        var createResult = await _userManager.CreateAsync(user, request.Password);
+        if (!createResult.Succeeded)
+        {
+            var errors = string.Join("; ", createResult.Errors.Select(e => e.Description));
+            _logger.LogWarning("User creation failed for {Email}: {Errors}", request.Email, errors);
+            return BadRequest(new { error = errors });
+        }
+
+        var roleResult = await _userManager.AddToRoleAsync(user, DefaultRole);
+        if (!roleResult.Succeeded)
+        {
+            _logger.LogError("Failed to assign {Role} role to user {UserId}: {Errors}",
+                DefaultRole, user.Id, string.Join("; ", roleResult.Errors.Select(e => e.Description)));
+        }
+
+        // Generate tokens
+        var accessToken = await _tokenService.GenerateAccessTokenAsync(user, ct);
+        var refreshToken = await _tokenService.GenerateRefreshTokenAsync(user.Id, ct);
+
+        SetRefreshTokenCookie(refreshToken.Token, refreshToken.ExpiresAtUtc);
+
+        _logger.LogInformation("User registered successfully: {UserId} ({Email})", user.Id, request.Email);
+
+        return Ok(new AuthResponse { AccessToken = accessToken });
+    }
+
+    [HttpPost("login")]
+    public async Task<IActionResult> Login([FromBody] LoginRequest request, CancellationToken ct)
+    {
+        var user = await _userManager.FindByEmailAsync(request.Email);
+        if (user is null)
+        {
+            _logger.LogWarning("Login attempt for non-existent email {Email}", request.Email);
+            return Unauthorized(new { error = "Invalid email or password." });
+        }
+
+        var signInResult = await _signInManager.CheckPasswordSignInAsync(user, request.Password, lockoutOnFailure: true);
+        if (!signInResult.Succeeded)
+        {
+            _logger.LogWarning("Failed login attempt for user {UserId} ({Email})", user.Id, request.Email);
+            return Unauthorized(new { error = "Invalid email or password." });
+        }
+
+        var accessToken = await _tokenService.GenerateAccessTokenAsync(user, ct);
+        var refreshToken = await _tokenService.GenerateRefreshTokenAsync(user.Id, ct);
+
+        SetRefreshTokenCookie(refreshToken.Token, refreshToken.ExpiresAtUtc);
+
+        _logger.LogInformation("User logged in: {UserId} ({Email})", user.Id, request.Email);
+
+        return Ok(new AuthResponse { AccessToken = accessToken });
     }
 
     [HttpPost("refresh")]
@@ -64,14 +192,14 @@ public class AuthController : ControllerBase
     }
 
     [Authorize]
-    [HttpPost("revoke")]
-    public async Task<IActionResult> Revoke(CancellationToken ct)
+    [HttpPost("logout")]
+    public async Task<IActionResult> Logout(CancellationToken ct)
     {
         var refreshTokenValue = Request.Cookies[RefreshTokenCookieName];
 
         if (string.IsNullOrWhiteSpace(refreshTokenValue))
         {
-            _logger.LogDebug("Revoke called with no refresh token cookie present");
+            _logger.LogDebug("Logout called with no refresh token cookie present");
             return NoContent();
         }
 
@@ -82,6 +210,142 @@ public class AuthController : ControllerBase
         _logger.LogInformation("Refresh token revoked via logout");
 
         return NoContent();
+    }
+
+    [HttpGet("providers")]
+    public IActionResult GetProviders()
+    {
+        var providers = new List<ProviderInfo>();
+
+        if (_oauthOptions.Google.Enabled
+            && !string.IsNullOrWhiteSpace(_oauthOptions.Google.ClientId)
+            && !string.IsNullOrWhiteSpace(_oauthOptions.Google.ClientSecret))
+        {
+            providers.Add(new ProviderInfo { Name = "Google" });
+        }
+
+        if (_oauthOptions.Microsoft.Enabled
+            && !string.IsNullOrWhiteSpace(_oauthOptions.Microsoft.ClientId)
+            && !string.IsNullOrWhiteSpace(_oauthOptions.Microsoft.ClientSecret))
+        {
+            providers.Add(new ProviderInfo { Name = "Microsoft" });
+        }
+
+        return Ok(providers);
+    }
+
+    [HttpGet("registration-mode")]
+    public IActionResult GetRegistrationMode()
+    {
+        return Ok(new { mode = _serverOptions.RegistrationMode.ToString() });
+    }
+
+    [HttpGet("external/{provider}")]
+    public IActionResult ExternalLogin(string provider)
+    {
+        if (!SupportedProviders.Contains(provider))
+        {
+            _logger.LogWarning("External login attempt with unsupported provider {Provider}", provider);
+            return BadRequest(new { error = $"Provider '{provider}' is not supported." });
+        }
+
+        var redirectUrl = Url.Action(nameof(ExternalCallback), "Auth");
+        var properties = new AuthenticationProperties { RedirectUri = redirectUrl };
+
+        return Challenge(properties, provider);
+    }
+
+    [HttpGet("external/callback")]
+    public async Task<IActionResult> ExternalCallback(CancellationToken ct)
+    {
+        var authenticateResult = await HttpContext.AuthenticateAsync(IdentityConstants.ExternalScheme);
+
+        if (!authenticateResult.Succeeded || authenticateResult.Principal is null)
+        {
+            _logger.LogWarning("External authentication callback failed");
+            return Unauthorized(new { error = "External authentication failed." });
+        }
+
+        var email = authenticateResult.Principal.FindFirstValue(ClaimTypes.Email);
+        var name = authenticateResult.Principal.FindFirstValue(ClaimTypes.Name);
+
+        if (string.IsNullOrWhiteSpace(email))
+        {
+            _logger.LogWarning("External authentication returned no email claim");
+            return BadRequest(new { error = "Email claim not provided by the external provider." });
+        }
+
+        var user = await _userManager.FindByEmailAsync(email);
+
+        if (user is null)
+        {
+            // Check registration mode for new OAuth users
+            if (_serverOptions.RegistrationMode == RegistrationMode.Closed)
+            {
+                _logger.LogWarning("OAuth registration rejected: registration is closed for {Email}", email);
+                return StatusCode(403, new { error = "Registration is currently closed." });
+            }
+
+            user = new AppUser
+            {
+                UserName = email,
+                Email = email,
+                DisplayName = name ?? email,
+                EmailConfirmed = true,
+                Status = UserStatus.Offline,
+                CreatedAtUtc = DateTime.UtcNow,
+                LastSeenUtc = DateTime.UtcNow,
+            };
+
+            var createResult = await _userManager.CreateAsync(user);
+            if (!createResult.Succeeded)
+            {
+                var errors = string.Join("; ", createResult.Errors.Select(e => e.Description));
+                _logger.LogError("Failed to create user via OAuth for {Email}: {Errors}", email, errors);
+                return BadRequest(new { error = errors });
+            }
+
+            var roleResult = await _userManager.AddToRoleAsync(user, DefaultRole);
+            if (!roleResult.Succeeded)
+            {
+                _logger.LogError("Failed to assign {Role} role to OAuth user {UserId}: {Errors}",
+                    DefaultRole, user.Id, string.Join("; ", roleResult.Errors.Select(e => e.Description)));
+            }
+
+            _logger.LogInformation("New user created via OAuth: {UserId} ({Email})", user.Id, email);
+        }
+
+        // Link external login if not already linked
+        var loginInfo = await _signInManager.GetExternalLoginInfoAsync();
+        if (loginInfo is not null)
+        {
+            var existingLogins = await _userManager.GetLoginsAsync(user);
+            var alreadyLinked = existingLogins.Any(l =>
+                l.LoginProvider == loginInfo.LoginProvider && l.ProviderKey == loginInfo.ProviderKey);
+
+            if (!alreadyLinked)
+            {
+                var addLoginResult = await _userManager.AddLoginAsync(user, loginInfo);
+                if (!addLoginResult.Succeeded)
+                {
+                    _logger.LogWarning("Failed to link external login for user {UserId}: {Errors}",
+                        user.Id, string.Join("; ", addLoginResult.Errors.Select(e => e.Description)));
+                }
+            }
+        }
+
+        // Sign out of the external cookie scheme
+        await HttpContext.SignOutAsync(IdentityConstants.ExternalScheme);
+
+        // Generate tokens
+        var accessToken = await _tokenService.GenerateAccessTokenAsync(user, ct);
+        var refreshToken = await _tokenService.GenerateRefreshTokenAsync(user.Id, ct);
+
+        SetRefreshTokenCookie(refreshToken.Token, refreshToken.ExpiresAtUtc);
+
+        _logger.LogInformation("User authenticated via OAuth: {UserId} ({Email})", user.Id, email);
+
+        return Ok(new AuthResponse { AccessToken = accessToken });
     }
 
     private void SetRefreshTokenCookie(string token, DateTime expiresAtUtc)

--- a/src/HotBox.Application/HotBox.Application.csproj
+++ b/src/HotBox.Application/HotBox.Application.csproj
@@ -7,7 +7,9 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="Microsoft.AspNetCore.Authentication.Google" Version="8.0.11" />
     <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="8.0.11" />
+    <PackageReference Include="Microsoft.AspNetCore.Authentication.MicrosoftAccount" Version="8.0.11" />
     <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="8.0.23" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="8.0.11">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/src/HotBox.Application/Models/AuthResponse.cs
+++ b/src/HotBox.Application/Models/AuthResponse.cs
@@ -1,0 +1,6 @@
+namespace HotBox.Application.Models;
+
+public class AuthResponse
+{
+    public string AccessToken { get; set; } = string.Empty;
+}

--- a/src/HotBox.Application/Models/LoginRequest.cs
+++ b/src/HotBox.Application/Models/LoginRequest.cs
@@ -1,0 +1,13 @@
+using System.ComponentModel.DataAnnotations;
+
+namespace HotBox.Application.Models;
+
+public class LoginRequest
+{
+    [Required]
+    [EmailAddress]
+    public string Email { get; set; } = string.Empty;
+
+    [Required]
+    public string Password { get; set; } = string.Empty;
+}

--- a/src/HotBox.Application/Models/ProviderInfo.cs
+++ b/src/HotBox.Application/Models/ProviderInfo.cs
@@ -1,0 +1,6 @@
+namespace HotBox.Application.Models;
+
+public class ProviderInfo
+{
+    public string Name { get; set; } = string.Empty;
+}

--- a/src/HotBox.Application/Models/RegisterRequest.cs
+++ b/src/HotBox.Application/Models/RegisterRequest.cs
@@ -1,0 +1,20 @@
+using System.ComponentModel.DataAnnotations;
+
+namespace HotBox.Application.Models;
+
+public class RegisterRequest
+{
+    [Required]
+    [EmailAddress]
+    public string Email { get; set; } = string.Empty;
+
+    [Required]
+    [MinLength(8)]
+    public string Password { get; set; } = string.Empty;
+
+    [Required]
+    [MaxLength(32)]
+    public string DisplayName { get; set; } = string.Empty;
+
+    public string? InviteCode { get; set; }
+}

--- a/src/HotBox.Application/Program.cs
+++ b/src/HotBox.Application/Program.cs
@@ -1,5 +1,6 @@
 using HotBox.Application.DependencyInjection;
 using HotBox.Infrastructure.Data;
+using HotBox.Infrastructure.Data.Seeding;
 using HotBox.Infrastructure.DependencyInjection;
 using Microsoft.EntityFrameworkCore;
 using Serilog;
@@ -20,6 +21,7 @@ try
     // Add services to the container.
     builder.Services.AddInfrastructure(builder.Configuration);
     builder.Services.AddApplicationServices(builder.Configuration);
+    builder.Services.AddHostedService<DatabaseSeeder>();
 
     var app = builder.Build();
 

--- a/src/HotBox.Core/Interfaces/IInviteService.cs
+++ b/src/HotBox.Core/Interfaces/IInviteService.cs
@@ -1,0 +1,14 @@
+using HotBox.Core.Entities;
+
+namespace HotBox.Core.Interfaces;
+
+public interface IInviteService
+{
+    Task<Invite> GenerateAsync(Guid createdByUserId, DateTime? expiresAtUtc = null, int? maxUses = null, CancellationToken ct = default);
+
+    Task<Invite?> ValidateAndConsumeAsync(string code, CancellationToken ct = default);
+
+    Task<bool> RevokeAsync(string code, CancellationToken ct = default);
+
+    Task<IReadOnlyList<Invite>> GetAllAsync(CancellationToken ct = default);
+}

--- a/src/HotBox.Infrastructure/Data/Seeding/DatabaseSeeder.cs
+++ b/src/HotBox.Infrastructure/Data/Seeding/DatabaseSeeder.cs
@@ -1,0 +1,209 @@
+using HotBox.Core.Entities;
+using HotBox.Core.Enums;
+using HotBox.Core.Options;
+using Microsoft.AspNetCore.Identity;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+
+namespace HotBox.Infrastructure.Data.Seeding;
+
+public class DatabaseSeeder : IHostedService
+{
+    private readonly IServiceProvider _serviceProvider;
+    private readonly ILogger<DatabaseSeeder> _logger;
+
+    public static readonly string[] RoleNames = ["Admin", "Moderator", "Member"];
+
+    public DatabaseSeeder(IServiceProvider serviceProvider, ILogger<DatabaseSeeder> logger)
+    {
+        _serviceProvider = serviceProvider;
+        _logger = logger;
+    }
+
+    public async Task StartAsync(CancellationToken cancellationToken)
+    {
+        _logger.LogInformation("Database seeding started");
+
+        using var scope = _serviceProvider.CreateScope();
+        var roleManager = scope.ServiceProvider.GetRequiredService<RoleManager<IdentityRole<Guid>>>();
+        var userManager = scope.ServiceProvider.GetRequiredService<UserManager<AppUser>>();
+        var adminSeedOptions = scope.ServiceProvider.GetRequiredService<IOptions<AdminSeedOptions>>().Value;
+        var dbContext = scope.ServiceProvider.GetRequiredService<HotBoxDbContext>();
+
+        await SeedRolesAsync(roleManager);
+        var adminUser = await SeedAdminUserAsync(userManager, adminSeedOptions);
+        await SeedDefaultChannelsAsync(dbContext, userManager, adminUser);
+
+        _logger.LogInformation("Database seeding completed");
+    }
+
+    public Task StopAsync(CancellationToken cancellationToken) => Task.CompletedTask;
+
+    private async Task SeedRolesAsync(RoleManager<IdentityRole<Guid>> roleManager)
+    {
+        foreach (var roleName in RoleNames)
+        {
+            if (await roleManager.RoleExistsAsync(roleName))
+            {
+                _logger.LogDebug("Role {RoleName} already exists, skipping", roleName);
+                continue;
+            }
+
+            var result = await roleManager.CreateAsync(new IdentityRole<Guid>(roleName));
+            if (result.Succeeded)
+            {
+                _logger.LogInformation("Seeded role {RoleName}", roleName);
+            }
+            else
+            {
+                _logger.LogError("Failed to seed role {RoleName}: {Errors}", roleName,
+                    string.Join(", ", result.Errors.Select(e => e.Description)));
+            }
+        }
+    }
+
+    private async Task<AppUser?> SeedAdminUserAsync(
+        UserManager<AppUser> userManager,
+        AdminSeedOptions options)
+    {
+        // Check if AdminSeed config is populated
+        if (string.IsNullOrWhiteSpace(options.Email) ||
+            string.IsNullOrWhiteSpace(options.Password) ||
+            string.IsNullOrWhiteSpace(options.DisplayName))
+        {
+            _logger.LogWarning("AdminSeed configuration is incomplete, skipping admin user seeding. " +
+                               "Set AdminSeed:Email, AdminSeed:Password, and AdminSeed:DisplayName to seed an admin user");
+            return null;
+        }
+
+        // Check if any user with Admin role already exists
+        var admins = await userManager.GetUsersInRoleAsync("Admin");
+        if (admins.Count > 0)
+        {
+            _logger.LogDebug("Admin user already exists, skipping admin seeding");
+            return admins[0];
+        }
+
+        // Check if a user with the configured email already exists
+        var existingUser = await userManager.FindByEmailAsync(options.Email);
+        if (existingUser != null)
+        {
+            _logger.LogInformation("User with email {Email} already exists, assigning Admin role", options.Email);
+            var roleResult = await userManager.AddToRoleAsync(existingUser, "Admin");
+            if (!roleResult.Succeeded)
+            {
+                _logger.LogError("Failed to assign Admin role to existing user {Email}: {Errors}",
+                    options.Email,
+                    string.Join(", ", roleResult.Errors.Select(e => e.Description)));
+            }
+
+            return existingUser;
+        }
+
+        // Create the admin user
+        var adminUser = new AppUser
+        {
+            UserName = options.Email,
+            Email = options.Email,
+            DisplayName = options.DisplayName,
+            EmailConfirmed = true,
+            Status = UserStatus.Offline,
+            CreatedAtUtc = DateTime.UtcNow,
+            LastSeenUtc = DateTime.UtcNow
+        };
+
+        var createResult = await userManager.CreateAsync(adminUser, options.Password);
+        if (!createResult.Succeeded)
+        {
+            _logger.LogError("Failed to create admin user {Email}: {Errors}",
+                options.Email,
+                string.Join(", ", createResult.Errors.Select(e => e.Description)));
+            return null;
+        }
+
+        var addRoleResult = await userManager.AddToRoleAsync(adminUser, "Admin");
+        if (!addRoleResult.Succeeded)
+        {
+            _logger.LogError("Failed to assign Admin role to new user {Email}: {Errors}",
+                options.Email,
+                string.Join(", ", addRoleResult.Errors.Select(e => e.Description)));
+            return null;
+        }
+
+        _logger.LogInformation("Seeded admin user {Email} with display name {DisplayName}",
+            options.Email, options.DisplayName);
+
+        return adminUser;
+    }
+
+    private async Task SeedDefaultChannelsAsync(
+        HotBoxDbContext dbContext,
+        UserManager<AppUser> userManager,
+        AppUser? adminUser)
+    {
+        // If no admin user was provided, try to find one
+        if (adminUser == null)
+        {
+            var admins = await userManager.GetUsersInRoleAsync("Admin");
+            if (admins.Count == 0)
+            {
+                _logger.LogWarning("No admin user exists, skipping default channel seeding. " +
+                                   "Channels require a CreatedByUserId");
+                return;
+            }
+
+            adminUser = admins[0];
+        }
+
+        // Only seed channels if none exist
+        var hasChannels = await dbContext.Channels.AnyAsync();
+        if (hasChannels)
+        {
+            _logger.LogDebug("Channels already exist, skipping default channel seeding");
+            return;
+        }
+
+        var now = DateTime.UtcNow;
+        var defaultChannels = new List<Channel>
+        {
+            new()
+            {
+                Id = Guid.NewGuid(),
+                Name = "general",
+                Topic = "General discussion",
+                Type = ChannelType.Text,
+                SortOrder = 0,
+                CreatedAtUtc = now,
+                CreatedByUserId = adminUser.Id
+            },
+            new()
+            {
+                Id = Guid.NewGuid(),
+                Name = "random",
+                Topic = "Off-topic conversation",
+                Type = ChannelType.Text,
+                SortOrder = 1,
+                CreatedAtUtc = now,
+                CreatedByUserId = adminUser.Id
+            },
+            new()
+            {
+                Id = Guid.NewGuid(),
+                Name = "General",
+                Type = ChannelType.Voice,
+                SortOrder = 0,
+                CreatedAtUtc = now,
+                CreatedByUserId = adminUser.Id
+            }
+        };
+
+        dbContext.Channels.AddRange(defaultChannels);
+        await dbContext.SaveChangesAsync();
+
+        _logger.LogInformation("Seeded {ChannelCount} default channels (general, random, General voice)",
+            defaultChannels.Count);
+    }
+}

--- a/src/HotBox.Infrastructure/DependencyInjection/InfrastructureServiceExtensions.cs
+++ b/src/HotBox.Infrastructure/DependencyInjection/InfrastructureServiceExtensions.cs
@@ -89,6 +89,7 @@ public static class InfrastructureServiceExtensions
 
         // Register services
         services.AddScoped<ITokenService, TokenService>();
+        services.AddScoped<IInviteService, InviteService>();
 
         return services;
     }

--- a/src/HotBox.Infrastructure/Services/InviteService.cs
+++ b/src/HotBox.Infrastructure/Services/InviteService.cs
@@ -1,0 +1,138 @@
+using System.Security.Cryptography;
+using HotBox.Core.Entities;
+using HotBox.Core.Interfaces;
+using HotBox.Infrastructure.Data;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Logging;
+
+namespace HotBox.Infrastructure.Services;
+
+public class InviteService : IInviteService
+{
+    private const int CodeByteLength = 6; // 6 bytes → 8 Base64URL chars
+    private readonly HotBoxDbContext _context;
+    private readonly ILogger<InviteService> _logger;
+
+    public InviteService(
+        HotBoxDbContext context,
+        ILogger<InviteService> logger)
+    {
+        _context = context;
+        _logger = logger;
+    }
+
+    public async Task<Invite> GenerateAsync(
+        Guid createdByUserId,
+        DateTime? expiresAtUtc = null,
+        int? maxUses = null,
+        CancellationToken ct = default)
+    {
+        var code = GenerateCode();
+
+        var invite = new Invite
+        {
+            Id = Guid.NewGuid(),
+            Code = code,
+            CreatedByUserId = createdByUserId,
+            CreatedAtUtc = DateTime.UtcNow,
+            ExpiresAtUtc = expiresAtUtc,
+            MaxUses = maxUses,
+            UseCount = 0,
+            IsRevoked = false,
+        };
+
+        _context.Invites.Add(invite);
+        await _context.SaveChangesAsync(ct);
+
+        _logger.LogInformation(
+            "Generated invite code {InviteCode} by user {UserId} (expires: {ExpiresAtUtc}, maxUses: {MaxUses})",
+            code,
+            createdByUserId,
+            expiresAtUtc?.ToString("o") ?? "never",
+            maxUses?.ToString() ?? "unlimited");
+
+        return invite;
+    }
+
+    public async Task<Invite?> ValidateAndConsumeAsync(string code, CancellationToken ct = default)
+    {
+        var invite = await _context.Invites
+            .FirstOrDefaultAsync(i => i.Code == code, ct);
+
+        if (invite is null)
+        {
+            _logger.LogWarning("Invite code {InviteCode} not found", code);
+            return null;
+        }
+
+        if (invite.IsRevoked)
+        {
+            _logger.LogWarning("Invite code {InviteCode} has been revoked", code);
+            return null;
+        }
+
+        if (invite.ExpiresAtUtc.HasValue && invite.ExpiresAtUtc.Value <= DateTime.UtcNow)
+        {
+            _logger.LogWarning("Invite code {InviteCode} has expired", code);
+            return null;
+        }
+
+        if (invite.MaxUses.HasValue && invite.UseCount >= invite.MaxUses.Value)
+        {
+            _logger.LogWarning("Invite code {InviteCode} has reached max uses ({MaxUses})", code, invite.MaxUses.Value);
+            return null;
+        }
+
+        invite.UseCount++;
+        await _context.SaveChangesAsync(ct);
+
+        _logger.LogInformation(
+            "Invite code {InviteCode} consumed (use {UseCount}/{MaxUses})",
+            code,
+            invite.UseCount,
+            invite.MaxUses?.ToString() ?? "unlimited");
+
+        return invite;
+    }
+
+    public async Task<bool> RevokeAsync(string code, CancellationToken ct = default)
+    {
+        var invite = await _context.Invites
+            .FirstOrDefaultAsync(i => i.Code == code, ct);
+
+        if (invite is null)
+        {
+            _logger.LogWarning("Attempted to revoke non-existent invite code {InviteCode}", code);
+            return false;
+        }
+
+        if (invite.IsRevoked)
+        {
+            _logger.LogDebug("Invite code {InviteCode} is already revoked", code);
+            return true;
+        }
+
+        invite.IsRevoked = true;
+        await _context.SaveChangesAsync(ct);
+
+        _logger.LogInformation("Revoked invite code {InviteCode}", code);
+        return true;
+    }
+
+    public async Task<IReadOnlyList<Invite>> GetAllAsync(CancellationToken ct = default)
+    {
+        return await _context.Invites
+            .AsNoTracking()
+            .OrderByDescending(i => i.CreatedAtUtc)
+            .ToListAsync(ct);
+    }
+
+    private static string GenerateCode()
+    {
+        var bytes = RandomNumberGenerator.GetBytes(CodeByteLength);
+        return Convert.ToBase64String(bytes)
+            .Replace('+', '-')
+            .Replace('/', '_')
+            .TrimEnd('=');
+    }
+}


### PR DESCRIPTION
## Summary

Completes all remaining Phase 2 (Authentication & User Management) sub-issues:

- **AuthController endpoints** (#26): Register, login, logout, refresh, providers, registration-mode, OAuth external login/callback
- **Registration mode enforcement** (#25): Open / InviteOnly / Closed modes via `ServerOptions.RegistrationMode`
- **OAuth integration** (#24): Google and Microsoft providers, conditionally enabled when credentials are configured
- **Invite code system** (#28): `InviteService` with cryptographically random codes, expiry, max-use limits, usage tracking
- **Admin/role seeding** (#27): `DatabaseSeeder` hosted service seeds Admin/Moderator/Member roles and admin user from config
- **Default channel seeding** (#29): Seeds #general, #random (text) and General (voice) channels on first run

### New files
| File | Purpose |
|------|---------|
| `Infrastructure/Data/Seeding/DatabaseSeeder.cs` | Startup seeder (roles, admin, channels) |
| `Infrastructure/Services/InviteService.cs` | Invite code generation, validation, revocation |
| `Core/Interfaces/IInviteService.cs` | Invite service contract |
| `Application/Models/*.cs` | Request/response DTOs (RegisterRequest, LoginRequest, AuthResponse, ProviderInfo) |

### Modified files
| File | Changes |
|------|---------|
| `AuthController.cs` | Added register, login, logout, providers, registration-mode, OAuth endpoints |
| `ApplicationServiceExtensions.cs` | Conditional Google/Microsoft OAuth registration |
| `InfrastructureServiceExtensions.cs` | Registered `IInviteService` |
| `Program.cs` | Registered `DatabaseSeeder` hosted service |
| `HotBox.Application.csproj` | Added Google/Microsoft auth NuGet packages |

Closes #24, closes #25, closes #26, closes #27, closes #28, closes #29

## Test plan

- [ ] Verify `dotnet build` succeeds (confirmed: 0 warnings, 0 errors)
- [ ] Test registration in Open mode (no invite code required)
- [ ] Test registration in InviteOnly mode (requires valid invite code)
- [ ] Test registration in Closed mode (returns 403)
- [ ] Test login with valid/invalid credentials
- [ ] Test logout revokes refresh token and clears cookie
- [ ] Test token refresh flow
- [ ] Test `GET /api/auth/providers` returns only enabled providers
- [ ] Test `GET /api/auth/registration-mode` returns current mode
- [ ] Test admin/role/channel seeding on first startup with populated AdminSeed config
- [ ] Test seeder is idempotent on subsequent startups
- [ ] Test OAuth flow with Google/Microsoft (requires provider credentials)

🤖 Generated with [Claude Code](https://claude.com/claude-code)