### PR TITLE
feat: add messaging services, ChatHub, and REST endpoints (#30, #31, #32, #33)

### DIFF
--- a/src/HotBox.Application/Controllers/ChannelsController.cs
+++ b/src/HotBox.Application/Controllers/ChannelsController.cs
@@ -1,0 +1,170 @@
+using System.Security.Claims;
+using HotBox.Application.Models;
+using HotBox.Core.Interfaces;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
+
+namespace HotBox.Application.Controllers;
+
+[ApiController]
+[Route("api/channels")]
+[Authorize]
+public class ChannelsController : ControllerBase
+{
+    private readonly IChannelService _channelService;
+    private readonly ILogger<ChannelsController> _logger;
+
+    public ChannelsController(
+        IChannelService channelService,
+        ILogger<ChannelsController> logger)
+    {
+        _channelService = channelService;
+        _logger = logger;
+    }
+
+    [HttpGet]
+    public async Task<IActionResult> GetAll(CancellationToken ct)
+    {
+        var channels = await _channelService.GetAllAsync(ct);
+
+        var response = channels.Select(c => new ChannelResponse
+        {
+            Id = c.Id,
+            Name = c.Name,
+            Topic = c.Topic,
+            Type = c.Type,
+            SortOrder = c.SortOrder,
+            CreatedAtUtc = c.CreatedAtUtc,
+        }).ToList();
+
+        return Ok(response);
+    }
+
+    [HttpGet("{id:guid}")]
+    public async Task<IActionResult> GetById(Guid id, CancellationToken ct)
+    {
+        var channel = await _channelService.GetByIdAsync(id, ct);
+        if (channel is null)
+        {
+            return NotFound(new { error = $"Channel {id} not found." });
+        }
+
+        var response = new ChannelResponse
+        {
+            Id = channel.Id,
+            Name = channel.Name,
+            Topic = channel.Topic,
+            Type = channel.Type,
+            SortOrder = channel.SortOrder,
+            CreatedAtUtc = channel.CreatedAtUtc,
+        };
+
+        return Ok(response);
+    }
+
+    [HttpPost]
+    public async Task<IActionResult> Create([FromBody] CreateChannelRequest request, CancellationToken ct)
+    {
+        var userId = GetUserId();
+        if (userId is null)
+        {
+            return Unauthorized(new { error = "Unable to determine user identity." });
+        }
+
+        try
+        {
+            var channel = await _channelService.CreateAsync(
+                userId.Value, request.Name, request.Topic, request.Type, ct);
+
+            var response = new ChannelResponse
+            {
+                Id = channel.Id,
+                Name = channel.Name,
+                Topic = channel.Topic,
+                Type = channel.Type,
+                SortOrder = channel.SortOrder,
+                CreatedAtUtc = channel.CreatedAtUtc,
+            };
+
+            return CreatedAtAction(nameof(GetById), new { id = channel.Id }, response);
+        }
+        catch (UnauthorizedAccessException ex)
+        {
+            _logger.LogWarning("Channel creation denied for user {UserId}: {Reason}", userId, ex.Message);
+            return StatusCode(403, new { error = ex.Message });
+        }
+        catch (InvalidOperationException ex)
+        {
+            return BadRequest(new { error = ex.Message });
+        }
+        catch (KeyNotFoundException ex)
+        {
+            return NotFound(new { error = ex.Message });
+        }
+    }
+
+    [HttpPut("{id:guid}")]
+    public async Task<IActionResult> Update(Guid id, [FromBody] UpdateChannelRequest request, CancellationToken ct)
+    {
+        var userId = GetUserId();
+        if (userId is null)
+        {
+            return Unauthorized(new { error = "Unable to determine user identity." });
+        }
+
+        try
+        {
+            await _channelService.UpdateAsync(userId.Value, id, request.Name, request.Topic, ct);
+            return Ok(new { message = "Channel updated." });
+        }
+        catch (UnauthorizedAccessException ex)
+        {
+            _logger.LogWarning("Channel update denied for user {UserId}: {Reason}", userId, ex.Message);
+            return StatusCode(403, new { error = ex.Message });
+        }
+        catch (InvalidOperationException ex)
+        {
+            return BadRequest(new { error = ex.Message });
+        }
+        catch (KeyNotFoundException ex)
+        {
+            return NotFound(new { error = ex.Message });
+        }
+    }
+
+    [HttpDelete("{id:guid}")]
+    public async Task<IActionResult> Delete(Guid id, CancellationToken ct)
+    {
+        var userId = GetUserId();
+        if (userId is null)
+        {
+            return Unauthorized(new { error = "Unable to determine user identity." });
+        }
+
+        try
+        {
+            await _channelService.DeleteAsync(userId.Value, id, ct);
+            return Ok(new { message = "Channel deleted." });
+        }
+        catch (UnauthorizedAccessException ex)
+        {
+            _logger.LogWarning("Channel deletion denied for user {UserId}: {Reason}", userId, ex.Message);
+            return StatusCode(403, new { error = ex.Message });
+        }
+        catch (KeyNotFoundException ex)
+        {
+            return NotFound(new { error = ex.Message });
+        }
+    }
+
+    private Guid? GetUserId()
+    {
+        var userIdClaim = User.FindFirst(ClaimTypes.NameIdentifier)?.Value;
+        if (string.IsNullOrWhiteSpace(userIdClaim) || !Guid.TryParse(userIdClaim, out var userId))
+        {
+            return null;
+        }
+
+        return userId;
+    }
+}

--- a/src/HotBox.Application/Controllers/MessagesController.cs
+++ b/src/HotBox.Application/Controllers/MessagesController.cs
@@ -1,0 +1,74 @@
+using HotBox.Application.Models;
+using HotBox.Core.Interfaces;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
+
+namespace HotBox.Application.Controllers;
+
+[ApiController]
+[Route("api")]
+[Authorize]
+public class MessagesController : ControllerBase
+{
+    private readonly IMessageService _messageService;
+    private readonly ILogger<MessagesController> _logger;
+
+    public MessagesController(
+        IMessageService messageService,
+        ILogger<MessagesController> logger)
+    {
+        _messageService = messageService;
+        _logger = logger;
+    }
+
+    [HttpGet("channels/{channelId:guid}/messages")]
+    public async Task<IActionResult> GetByChannel(
+        Guid channelId,
+        [FromQuery] DateTime? before = null,
+        [FromQuery] int limit = 50,
+        CancellationToken ct = default)
+    {
+        if (limit is < 1 or > 100)
+        {
+            return BadRequest(new { error = "Limit must be between 1 and 100." });
+        }
+
+        var messages = await _messageService.GetByChannelAsync(channelId, before, limit, ct);
+
+        var response = messages.Select(m => new MessageResponse
+        {
+            Id = m.Id,
+            Content = m.Content,
+            ChannelId = m.ChannelId,
+            AuthorId = m.AuthorId,
+            AuthorDisplayName = m.Author?.DisplayName ?? "Unknown",
+            CreatedAtUtc = m.CreatedAtUtc,
+            EditedAtUtc = m.EditedAtUtc,
+        }).ToList();
+
+        return Ok(response);
+    }
+
+    [HttpGet("messages/{id:guid}")]
+    public async Task<IActionResult> GetById(Guid id, CancellationToken ct)
+    {
+        var message = await _messageService.GetByIdAsync(id, ct);
+        if (message is null)
+        {
+            return NotFound(new { error = $"Message {id} not found." });
+        }
+
+        var response = new MessageResponse
+        {
+            Id = message.Id,
+            Content = message.Content,
+            ChannelId = message.ChannelId,
+            AuthorId = message.AuthorId,
+            AuthorDisplayName = message.Author?.DisplayName ?? "Unknown",
+            CreatedAtUtc = message.CreatedAtUtc,
+            EditedAtUtc = message.EditedAtUtc,
+        };
+
+        return Ok(response);
+    }
+}

--- a/src/HotBox.Application/Hubs/ChatHub.cs
+++ b/src/HotBox.Application/Hubs/ChatHub.cs
@@ -1,0 +1,114 @@
+using System.Security.Claims;
+using HotBox.Application.Models;
+using HotBox.Core.Entities;
+using HotBox.Core.Interfaces;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Identity;
+using Microsoft.AspNetCore.SignalR;
+using Microsoft.Extensions.Logging;
+
+namespace HotBox.Application.Hubs;
+
+[Authorize]
+public class ChatHub : Hub
+{
+    private readonly IMessageService _messageService;
+    private readonly UserManager<AppUser> _userManager;
+    private readonly ILogger<ChatHub> _logger;
+
+    public ChatHub(
+        IMessageService messageService,
+        UserManager<AppUser> userManager,
+        ILogger<ChatHub> logger)
+    {
+        _messageService = messageService;
+        _userManager = userManager;
+        _logger = logger;
+    }
+
+    public async Task JoinChannel(Guid channelId)
+    {
+        var userId = GetUserId();
+        var displayName = await GetDisplayNameAsync(userId);
+
+        await Groups.AddToGroupAsync(Context.ConnectionId, channelId.ToString());
+
+        _logger.LogInformation(
+            "User {UserId} joined channel {ChannelId}",
+            userId, channelId);
+
+        await Clients.Group(channelId.ToString())
+            .SendAsync("UserJoinedChannel", channelId, userId, displayName);
+    }
+
+    public async Task LeaveChannel(Guid channelId)
+    {
+        var userId = GetUserId();
+
+        await Groups.RemoveFromGroupAsync(Context.ConnectionId, channelId.ToString());
+
+        _logger.LogInformation(
+            "User {UserId} left channel {ChannelId}",
+            userId, channelId);
+
+        await Clients.Group(channelId.ToString())
+            .SendAsync("UserLeftChannel", channelId, userId);
+    }
+
+    public async Task SendMessage(Guid channelId, string content)
+    {
+        if (string.IsNullOrWhiteSpace(content))
+            throw new HubException("Message content cannot be empty.");
+
+        var userId = GetUserId();
+
+        var message = await _messageService.SendAsync(channelId, userId, content);
+
+        var response = new MessageResponse
+        {
+            Id = message.Id,
+            Content = message.Content,
+            ChannelId = message.ChannelId,
+            AuthorId = message.AuthorId,
+            AuthorDisplayName = message.Author?.DisplayName ?? "Unknown",
+            CreatedAtUtc = message.CreatedAtUtc,
+        };
+
+        await Clients.Group(channelId.ToString())
+            .SendAsync("ReceiveMessage", response);
+    }
+
+    public async Task StartTyping(Guid channelId)
+    {
+        var userId = GetUserId();
+        var displayName = await GetDisplayNameAsync(userId);
+
+        await Clients.OthersInGroup(channelId.ToString())
+            .SendAsync("UserTyping", channelId, userId, displayName);
+    }
+
+    public async Task StopTyping(Guid channelId)
+    {
+        var userId = GetUserId();
+
+        await Clients.OthersInGroup(channelId.ToString())
+            .SendAsync("UserStoppedTyping", channelId, userId);
+    }
+
+    private Guid GetUserId()
+    {
+        var userIdClaim = Context.User?.FindFirst(ClaimTypes.NameIdentifier)?.Value;
+        if (string.IsNullOrWhiteSpace(userIdClaim) || !Guid.TryParse(userIdClaim, out var userId))
+        {
+            throw new HubException("Unable to determine user identity.");
+        }
+
+        return userId;
+    }
+
+    private async Task<string> GetDisplayNameAsync(Guid userId)
+    {
+        var user = await _userManager.FindByIdAsync(userId.ToString());
+        return user?.DisplayName ?? "Unknown";
+    }
+}

--- a/src/HotBox.Application/Models/ChannelResponse.cs
+++ b/src/HotBox.Application/Models/ChannelResponse.cs
@@ -1,0 +1,18 @@
+using HotBox.Core.Enums;
+
+namespace HotBox.Application.Models;
+
+public class ChannelResponse
+{
+    public Guid Id { get; set; }
+
+    public string Name { get; set; } = string.Empty;
+
+    public string? Topic { get; set; }
+
+    public ChannelType Type { get; set; }
+
+    public int SortOrder { get; set; }
+
+    public DateTime CreatedAtUtc { get; set; }
+}

--- a/src/HotBox.Application/Models/CreateChannelRequest.cs
+++ b/src/HotBox.Application/Models/CreateChannelRequest.cs
@@ -1,0 +1,15 @@
+using System.ComponentModel.DataAnnotations;
+using HotBox.Core.Enums;
+
+namespace HotBox.Application.Models;
+
+public class CreateChannelRequest
+{
+    [Required]
+    public string Name { get; set; } = string.Empty;
+
+    public string? Topic { get; set; }
+
+    [Required]
+    public ChannelType Type { get; set; }
+}

--- a/src/HotBox.Application/Models/MessageResponse.cs
+++ b/src/HotBox.Application/Models/MessageResponse.cs
@@ -1,0 +1,18 @@
+namespace HotBox.Application.Models;
+
+public class MessageResponse
+{
+    public Guid Id { get; set; }
+
+    public string Content { get; set; } = string.Empty;
+
+    public Guid ChannelId { get; set; }
+
+    public Guid AuthorId { get; set; }
+
+    public string AuthorDisplayName { get; set; } = string.Empty;
+
+    public DateTime CreatedAtUtc { get; set; }
+
+    public DateTime? EditedAtUtc { get; set; }
+}

--- a/src/HotBox.Application/Models/UpdateChannelRequest.cs
+++ b/src/HotBox.Application/Models/UpdateChannelRequest.cs
@@ -1,0 +1,11 @@
+using System.ComponentModel.DataAnnotations;
+
+namespace HotBox.Application.Models;
+
+public class UpdateChannelRequest
+{
+    [Required]
+    public string Name { get; set; } = string.Empty;
+
+    public string? Topic { get; set; }
+}

--- a/src/HotBox.Application/Program.cs
+++ b/src/HotBox.Application/Program.cs
@@ -1,4 +1,5 @@
 using HotBox.Application.DependencyInjection;
+using HotBox.Application.Hubs;
 using HotBox.Infrastructure.Data;
 using HotBox.Infrastructure.Data.Seeding;
 using HotBox.Infrastructure.DependencyInjection;
@@ -47,6 +48,7 @@ try
     app.UseAuthentication();
     app.UseAuthorization();
     app.MapControllers();
+    app.MapHub<ChatHub>("/hubs/chat");
 
     app.Run();
 }

--- a/src/HotBox.Core/Interfaces/IChannelRepository.cs
+++ b/src/HotBox.Core/Interfaces/IChannelRepository.cs
@@ -16,4 +16,8 @@ public interface IChannelRepository
     Task UpdateAsync(Channel channel, CancellationToken ct = default);
 
     Task DeleteAsync(Guid id, CancellationToken ct = default);
+
+    Task<bool> ExistsByNameAsync(string name, Guid? excludeId = null, CancellationToken ct = default);
+
+    Task<int> GetMaxSortOrderAsync(CancellationToken ct = default);
 }

--- a/src/HotBox.Core/Interfaces/IChannelService.cs
+++ b/src/HotBox.Core/Interfaces/IChannelService.cs
@@ -1,0 +1,19 @@
+using HotBox.Core.Entities;
+using HotBox.Core.Enums;
+
+namespace HotBox.Core.Interfaces;
+
+public interface IChannelService
+{
+    Task<Channel> CreateAsync(Guid userId, string name, string? topic, ChannelType type, CancellationToken ct = default);
+
+    Task UpdateAsync(Guid userId, Guid channelId, string name, string? topic, CancellationToken ct = default);
+
+    Task DeleteAsync(Guid userId, Guid channelId, CancellationToken ct = default);
+
+    Task<IReadOnlyList<Channel>> GetAllAsync(CancellationToken ct = default);
+
+    Task<Channel?> GetByIdAsync(Guid id, CancellationToken ct = default);
+
+    Task<IReadOnlyList<Channel>> GetByTypeAsync(ChannelType type, CancellationToken ct = default);
+}

--- a/src/HotBox.Core/Interfaces/IMessageService.cs
+++ b/src/HotBox.Core/Interfaces/IMessageService.cs
@@ -1,0 +1,12 @@
+using HotBox.Core.Entities;
+
+namespace HotBox.Core.Interfaces;
+
+public interface IMessageService
+{
+    Task<Message> SendAsync(Guid channelId, Guid authorId, string content, CancellationToken ct = default);
+
+    Task<IReadOnlyList<Message>> GetByChannelAsync(Guid channelId, DateTime? before = null, int limit = 50, CancellationToken ct = default);
+
+    Task<Message?> GetByIdAsync(Guid id, CancellationToken ct = default);
+}

--- a/src/HotBox.Infrastructure/DependencyInjection/InfrastructureServiceExtensions.cs
+++ b/src/HotBox.Infrastructure/DependencyInjection/InfrastructureServiceExtensions.cs
@@ -90,6 +90,8 @@ public static class InfrastructureServiceExtensions
         // Register services
         services.AddScoped<ITokenService, TokenService>();
         services.AddScoped<IInviteService, InviteService>();
+        services.AddScoped<IChannelService, ChannelService>();
+        services.AddScoped<IMessageService, MessageService>();
 
         return services;
     }

--- a/src/HotBox.Infrastructure/Repositories/ChannelRepository.cs
+++ b/src/HotBox.Infrastructure/Repositories/ChannelRepository.cs
@@ -61,4 +61,26 @@ public class ChannelRepository : IChannelRepository
             await _context.SaveChangesAsync(ct);
         }
     }
+
+    public async Task<bool> ExistsByNameAsync(string name, Guid? excludeId = null, CancellationToken ct = default)
+    {
+        var query = _context.Channels.AsQueryable();
+
+        if (excludeId.HasValue)
+        {
+            query = query.Where(c => c.Id != excludeId.Value);
+        }
+
+        return await query.AnyAsync(c => c.Name.ToLower() == name.ToLower(), ct);
+    }
+
+    public async Task<int> GetMaxSortOrderAsync(CancellationToken ct = default)
+    {
+        if (!await _context.Channels.AnyAsync(ct))
+        {
+            return -1;
+        }
+
+        return await _context.Channels.MaxAsync(c => c.SortOrder, ct);
+    }
 }

--- a/src/HotBox.Infrastructure/Repositories/MessageRepository.cs
+++ b/src/HotBox.Infrastructure/Repositories/MessageRepository.cs
@@ -18,6 +18,7 @@ public class MessageRepository : IMessageRepository
     {
         return await _context.Messages
             .AsNoTracking()
+            .Include(m => m.Author)
             .FirstOrDefaultAsync(m => m.Id == id, ct);
     }
 
@@ -29,6 +30,7 @@ public class MessageRepository : IMessageRepository
     {
         var query = _context.Messages
             .AsNoTracking()
+            .Include(m => m.Author)
             .Where(m => m.ChannelId == channelId);
 
         if (before.HasValue)
@@ -49,6 +51,10 @@ public class MessageRepository : IMessageRepository
     {
         _context.Messages.Add(message);
         await _context.SaveChangesAsync(ct);
-        return message;
+
+        return await _context.Messages
+            .AsNoTracking()
+            .Include(m => m.Author)
+            .FirstAsync(m => m.Id == message.Id, ct);
     }
 }

--- a/src/HotBox.Infrastructure/Services/ChannelService.cs
+++ b/src/HotBox.Infrastructure/Services/ChannelService.cs
@@ -1,0 +1,154 @@
+using HotBox.Core.Entities;
+using HotBox.Core.Enums;
+using HotBox.Core.Interfaces;
+using Microsoft.AspNetCore.Identity;
+using Microsoft.Extensions.Logging;
+
+namespace HotBox.Infrastructure.Services;
+
+public class ChannelService : IChannelService
+{
+    private readonly IChannelRepository _channelRepository;
+    private readonly UserManager<AppUser> _userManager;
+    private readonly ILogger<ChannelService> _logger;
+
+    public ChannelService(
+        IChannelRepository channelRepository,
+        UserManager<AppUser> userManager,
+        ILogger<ChannelService> logger)
+    {
+        _channelRepository = channelRepository;
+        _userManager = userManager;
+        _logger = logger;
+    }
+
+    public async Task<Channel> CreateAsync(
+        Guid userId,
+        string name,
+        string? topic,
+        ChannelType type,
+        CancellationToken ct = default)
+    {
+        if (string.IsNullOrWhiteSpace(name))
+            throw new ArgumentException("Channel name cannot be empty.", nameof(name));
+
+        await EnsureAdminOrModeratorAsync(userId);
+
+        // Validate channel name uniqueness
+        if (await _channelRepository.ExistsByNameAsync(name, ct: ct))
+        {
+            throw new InvalidOperationException($"A channel with the name '{name}' already exists.");
+        }
+
+        var maxSortOrder = await _channelRepository.GetMaxSortOrderAsync(ct);
+
+        var channel = new Channel
+        {
+            Id = Guid.NewGuid(),
+            Name = name,
+            Topic = topic,
+            Type = type,
+            SortOrder = maxSortOrder + 1,
+            CreatedAtUtc = DateTime.UtcNow,
+            CreatedByUserId = userId,
+        };
+
+        var created = await _channelRepository.CreateAsync(channel, ct);
+
+        _logger.LogInformation(
+            "Channel {ChannelId} ({ChannelName}) created by user {UserId}",
+            created.Id, created.Name, userId);
+
+        return created;
+    }
+
+    public async Task UpdateAsync(
+        Guid userId,
+        Guid channelId,
+        string name,
+        string? topic,
+        CancellationToken ct = default)
+    {
+        if (string.IsNullOrWhiteSpace(name))
+            throw new ArgumentException("Channel name cannot be empty.", nameof(name));
+
+        await EnsureAdminOrModeratorAsync(userId);
+
+        var channel = await _channelRepository.GetByIdAsync(channelId, ct)
+            ?? throw new KeyNotFoundException($"Channel {channelId} not found.");
+
+        // Validate channel name uniqueness (excluding the current channel)
+        if (await _channelRepository.ExistsByNameAsync(name, excludeId: channelId, ct: ct))
+        {
+            throw new InvalidOperationException($"A channel with the name '{name}' already exists.");
+        }
+
+        channel.Name = name;
+        channel.Topic = topic;
+
+        await _channelRepository.UpdateAsync(channel, ct);
+
+        _logger.LogInformation(
+            "Channel {ChannelId} updated by user {UserId}",
+            channelId, userId);
+    }
+
+    public async Task DeleteAsync(Guid userId, Guid channelId, CancellationToken ct = default)
+    {
+        await EnsureAdminAsync(userId);
+
+        var channel = await _channelRepository.GetByIdAsync(channelId, ct)
+            ?? throw new KeyNotFoundException($"Channel {channelId} not found.");
+
+        await _channelRepository.DeleteAsync(channelId, ct);
+
+        _logger.LogInformation(
+            "Channel {ChannelId} ({ChannelName}) deleted by user {UserId}",
+            channelId, channel.Name, userId);
+    }
+
+    public async Task<IReadOnlyList<Channel>> GetAllAsync(CancellationToken ct = default)
+    {
+        return await _channelRepository.GetAllAsync(ct);
+    }
+
+    public async Task<Channel?> GetByIdAsync(Guid id, CancellationToken ct = default)
+    {
+        return await _channelRepository.GetByIdAsync(id, ct);
+    }
+
+    public async Task<IReadOnlyList<Channel>> GetByTypeAsync(ChannelType type, CancellationToken ct = default)
+    {
+        return await _channelRepository.GetByTypeAsync(type, ct);
+    }
+
+    private async Task EnsureAdminOrModeratorAsync(Guid userId)
+    {
+        var user = await _userManager.FindByIdAsync(userId.ToString())
+            ?? throw new KeyNotFoundException($"User {userId} not found.");
+
+        var roles = await _userManager.GetRolesAsync(user);
+        if (!roles.Contains("Admin") && !roles.Contains("Moderator"))
+        {
+            _logger.LogWarning(
+                "User {UserId} attempted channel operation without required role",
+                userId);
+            throw new UnauthorizedAccessException("Only Admin or Moderator roles can perform this operation.");
+        }
+    }
+
+    private async Task EnsureAdminAsync(Guid userId)
+    {
+        var user = await _userManager.FindByIdAsync(userId.ToString())
+            ?? throw new KeyNotFoundException($"User {userId} not found.");
+
+        var roles = await _userManager.GetRolesAsync(user);
+        if (!roles.Contains("Admin"))
+        {
+            _logger.LogWarning(
+                "User {UserId} attempted admin-only channel operation without Admin role",
+                userId);
+            throw new UnauthorizedAccessException("Only Admin role can perform this operation.");
+        }
+    }
+}

--- a/src/HotBox.Infrastructure/Services/MessageService.cs
+++ b/src/HotBox.Infrastructure/Services/MessageService.cs
@@ -1,0 +1,69 @@
+using HotBox.Core.Entities;
+using HotBox.Core.Interfaces;
+using Microsoft.Extensions.Logging;
+
+namespace HotBox.Infrastructure.Services;
+
+public class MessageService : IMessageService
+{
+    private readonly IMessageRepository _messageRepository;
+    private readonly IChannelRepository _channelRepository;
+    private readonly ILogger<MessageService> _logger;
+
+    public MessageService(
+        IMessageRepository messageRepository,
+        IChannelRepository channelRepository,
+        ILogger<MessageService> logger)
+    {
+        _messageRepository = messageRepository;
+        _channelRepository = channelRepository;
+        _logger = logger;
+    }
+
+    public async Task<Message> SendAsync(
+        Guid channelId,
+        Guid authorId,
+        string content,
+        CancellationToken ct = default)
+    {
+        if (string.IsNullOrWhiteSpace(content))
+            throw new ArgumentException("Message content cannot be empty.", nameof(content));
+
+        var channel = await _channelRepository.GetByIdAsync(channelId, ct)
+            ?? throw new KeyNotFoundException($"Channel {channelId} not found.");
+
+        var message = new Message
+        {
+            Id = Guid.NewGuid(),
+            Content = content,
+            ChannelId = channelId,
+            AuthorId = authorId,
+            CreatedAtUtc = DateTime.UtcNow,
+        };
+
+        var created = await _messageRepository.CreateAsync(message, ct);
+
+        _logger.LogInformation(
+            "Message {MessageId} sent to channel {ChannelId} by user {AuthorId}",
+            created.Id, channelId, authorId);
+
+        return created;
+    }
+
+    public async Task<IReadOnlyList<Message>> GetByChannelAsync(
+        Guid channelId,
+        DateTime? before = null,
+        int limit = 50,
+        CancellationToken ct = default)
+    {
+        var channel = await _channelRepository.GetByIdAsync(channelId, ct)
+            ?? throw new KeyNotFoundException($"Channel {channelId} not found.");
+
+        return await _messageRepository.GetByChannelAsync(channelId, before, limit, ct);
+    }
+
+    public async Task<Message?> GetByIdAsync(Guid id, CancellationToken ct = default)
+    {
+        return await _messageRepository.GetByIdAsync(id, ct);
+    }
+}


### PR DESCRIPTION
## Summary

- **ChannelService & IChannelService** (#30): CRUD operations with Admin/Moderator role-based authorization, channel name uniqueness validation via efficient `ExistsByNameAsync` repository query, and auto-incrementing sort order
- **MessageService & IMessageService** (#31): Message sending with channel validation, cursor-based pagination (50 per page), and author display name eager-loading via `Include(m => m.Author)`
- **ChatHub (SignalR)** (#32): Real-time messaging hub at `/hubs/chat` with `JoinChannel`, `LeaveChannel`, `SendMessage`, `StartTyping`, `StopTyping` methods — requires JWT authentication, broadcasts to channel groups
- **ChannelsController & MessagesController** (#33): REST endpoints for channel CRUD (`GET/POST/PUT/DELETE /api/channels`) and message retrieval (`GET /api/channels/{id}/messages?before=&limit=`) with proper DTOs, status codes, and input validation

### Files Changed (16 files, +711 lines)

**Core interfaces:**
- `IChannelService.cs`, `IMessageService.cs` (new)
- `IChannelRepository.cs` (added `ExistsByNameAsync`, `GetMaxSortOrderAsync`)

**Infrastructure services:**
- `ChannelService.cs`, `MessageService.cs` (new)
- `ChannelRepository.cs` (added new methods)
- `MessageRepository.cs` (added Author eager loading on create)
- `InfrastructureServiceExtensions.cs` (registered new services)

**Application layer:**
- `ChatHub.cs` (new)
- `ChannelsController.cs`, `MessagesController.cs` (new)
- DTOs: `CreateChannelRequest`, `UpdateChannelRequest`, `ChannelResponse`, `MessageResponse` (new)
- `Program.cs` (mapped ChatHub)

## Test plan

- [ ] Verify `dotnet build` succeeds with zero warnings/errors
- [ ] Test channel CRUD via REST: create, list, get by ID, update, delete
- [ ] Verify Admin/Mod-only authorization on channel create/update/delete
- [ ] Test message sending and cursor-based pagination via REST
- [ ] Test ChatHub: connect, join channel, send message, verify real-time broadcast
- [ ] Test typing indicators (StartTyping/StopTyping) via SignalR
- [ ] Verify channel name uniqueness validation rejects duplicates

Closes #30, closes #31, closes #32, closes #33

🤖 Generated with [Claude Code](https://claude.com/claude-code)