### PR TITLE
feat: implement direct messages with real-time delivery and UI (#4)

### DIFF
--- a/src/HotBox.Application/Controllers/DirectMessagesController.cs
+++ b/src/HotBox.Application/Controllers/DirectMessagesController.cs
@@ -1,0 +1,148 @@
+using System.Security.Claims;
+using HotBox.Application.Models;
+using HotBox.Core.Interfaces;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
+
+namespace HotBox.Application.Controllers;
+
+[ApiController]
+[Route("api/dm")]
+[Authorize]
+public class DirectMessagesController : ControllerBase
+{
+    private readonly IDirectMessageService _directMessageService;
+    private readonly ILogger<DirectMessagesController> _logger;
+
+    public DirectMessagesController(
+        IDirectMessageService directMessageService,
+        ILogger<DirectMessagesController> logger)
+    {
+        _directMessageService = directMessageService;
+        _logger = logger;
+    }
+
+    [HttpGet]
+    public async Task<IActionResult> GetConversations(CancellationToken ct)
+    {
+        var userId = GetUserId();
+        if (userId is null)
+        {
+            return Unauthorized();
+        }
+
+        _logger.LogDebug("Listing DM conversations for user {UserId}", userId.Value);
+
+        var conversations = await _directMessageService.GetConversationsAsync(userId.Value, ct);
+
+        var response = conversations.Select(c => new ConversationSummaryResponse
+        {
+            UserId = c.UserId,
+            DisplayName = c.DisplayName,
+            LastMessageContent = string.Empty,
+            LastMessageAtUtc = c.LastMessageAtUtc,
+            UnreadCount = 0,
+        }).ToList();
+
+        return Ok(response);
+    }
+
+    [HttpGet("{userId:guid}")]
+    public async Task<IActionResult> GetConversation(
+        Guid userId,
+        [FromQuery] DateTime? before = null,
+        [FromQuery] int limit = 50,
+        CancellationToken ct = default)
+    {
+        if (limit is < 1 or > 100)
+        {
+            return BadRequest(new { error = "Limit must be between 1 and 100." });
+        }
+
+        var currentUserId = GetUserId();
+        if (currentUserId is null)
+        {
+            return Unauthorized();
+        }
+
+        _logger.LogDebug(
+            "Fetching DM conversation between {CurrentUserId} and {OtherUserId}",
+            currentUserId.Value,
+            userId);
+
+        var messages = await _directMessageService.GetConversationAsync(
+            currentUserId.Value, userId, before, limit, ct);
+
+        var response = messages.Select(m => new DirectMessageResponse
+        {
+            Id = m.Id,
+            Content = m.Content,
+            SenderId = m.SenderId,
+            SenderDisplayName = m.Sender?.DisplayName ?? "Unknown",
+            RecipientId = m.RecipientId,
+            CreatedAtUtc = m.CreatedAtUtc,
+            ReadAtUtc = m.ReadAtUtc,
+        }).ToList();
+
+        return Ok(response);
+    }
+
+    [HttpPost("{userId:guid}")]
+    public async Task<IActionResult> SendMessage(
+        Guid userId,
+        [FromBody] SendDirectMessageRequest request,
+        CancellationToken ct)
+    {
+        var currentUserId = GetUserId();
+        if (currentUserId is null)
+        {
+            return Unauthorized();
+        }
+
+        _logger.LogDebug(
+            "User {SenderId} sending DM to {RecipientId}",
+            currentUserId.Value,
+            userId);
+
+        try
+        {
+            var message = await _directMessageService.SendAsync(
+                currentUserId.Value, userId, request.Content, ct);
+
+            var response = new DirectMessageResponse
+            {
+                Id = message.Id,
+                Content = message.Content,
+                SenderId = message.SenderId,
+                SenderDisplayName = message.Sender?.DisplayName ?? "Unknown",
+                RecipientId = message.RecipientId,
+                CreatedAtUtc = message.CreatedAtUtc,
+                ReadAtUtc = message.ReadAtUtc,
+            };
+
+            return CreatedAtAction(
+                nameof(GetConversation),
+                new { userId },
+                response);
+        }
+        catch (KeyNotFoundException ex)
+        {
+            return NotFound(new { error = ex.Message });
+        }
+        catch (ArgumentException ex)
+        {
+            return BadRequest(new { error = ex.Message });
+        }
+    }
+
+    private Guid? GetUserId()
+    {
+        var userIdClaim = User.FindFirst(ClaimTypes.NameIdentifier)?.Value;
+        if (string.IsNullOrWhiteSpace(userIdClaim) || !Guid.TryParse(userIdClaim, out var userId))
+        {
+            return null;
+        }
+
+        return userId;
+    }
+}

--- a/src/HotBox.Application/Models/ConversationSummaryResponse.cs
+++ b/src/HotBox.Application/Models/ConversationSummaryResponse.cs
@@ -1,0 +1,14 @@
+namespace HotBox.Application.Models;
+
+public class ConversationSummaryResponse
+{
+    public Guid UserId { get; set; }
+
+    public string DisplayName { get; set; } = string.Empty;
+
+    public string LastMessageContent { get; set; } = string.Empty;
+
+    public DateTime LastMessageAtUtc { get; set; }
+
+    public int UnreadCount { get; set; }
+}

--- a/src/HotBox.Application/Models/DirectMessageResponse.cs
+++ b/src/HotBox.Application/Models/DirectMessageResponse.cs
@@ -1,0 +1,18 @@
+namespace HotBox.Application.Models;
+
+public class DirectMessageResponse
+{
+    public Guid Id { get; set; }
+
+    public string Content { get; set; } = string.Empty;
+
+    public Guid SenderId { get; set; }
+
+    public string SenderDisplayName { get; set; } = string.Empty;
+
+    public Guid RecipientId { get; set; }
+
+    public DateTime CreatedAtUtc { get; set; }
+
+    public DateTime? ReadAtUtc { get; set; }
+}

--- a/src/HotBox.Application/Models/SendDirectMessageRequest.cs
+++ b/src/HotBox.Application/Models/SendDirectMessageRequest.cs
@@ -1,0 +1,9 @@
+using System.ComponentModel.DataAnnotations;
+
+namespace HotBox.Application.Models;
+
+public class SendDirectMessageRequest
+{
+    [Required]
+    public string Content { get; set; } = string.Empty;
+}

--- a/src/HotBox.Client/Components/DirectMessageInput.razor
+++ b/src/HotBox.Client/Components/DirectMessageInput.razor
@@ -1,0 +1,108 @@
+@using HotBox.Client.State
+@using HotBox.Client.Services
+@inject DirectMessageState DirectMessageState
+@inject ChatHubService ChatHub
+@implements IDisposable
+
+<div class="message-input-wrapper">
+    <div class="message-input">
+        <input type="text"
+               @bind="MessageText"
+               @bind:event="oninput"
+               @onkeydown="HandleKeyDown"
+               placeholder="@GetPlaceholder()"
+               disabled="@(DirectMessageState.ActiveConversationUserId is null)" />
+        <button @onclick="SendMessage"
+                disabled="@(DirectMessageState.ActiveConversationUserId is null)"
+                aria-label="Send message">
+            <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+                <line x1="22" y1="2" x2="11" y2="13"></line>
+                <polygon points="22 2 15 22 11 13 2 9 22 2"></polygon>
+            </svg>
+        </button>
+    </div>
+    @if (DirectMessageState.TypingDisplayNames.Count > 0)
+    {
+        <div class="typing-indicator">
+            @FormatTypingText()
+        </div>
+    }
+</div>
+
+@code {
+    private string MessageText { get; set; } = string.Empty;
+    private DateTime _lastTypingSignal = DateTime.MinValue;
+    private static readonly TimeSpan TypingDebounceInterval = TimeSpan.FromSeconds(3);
+
+    protected override void OnInitialized()
+    {
+        DirectMessageState.OnChange += StateHasChanged;
+    }
+
+    private string GetPlaceholder()
+    {
+        if (DirectMessageState.ActiveConversationUserId is null)
+            return "Select a conversation to start chatting";
+
+        return $"Message @{DirectMessageState.ActiveConversationDisplayName}";
+    }
+
+    private async Task HandleKeyDown(Microsoft.AspNetCore.Components.Web.KeyboardEventArgs e)
+    {
+        if (e.Key == "Enter" && !e.ShiftKey)
+        {
+            await SendMessage();
+            return;
+        }
+
+        // Debounced typing indicator
+        await SendTypingSignalAsync();
+    }
+
+    private async Task SendMessage()
+    {
+        var content = MessageText.Trim();
+        if (string.IsNullOrEmpty(content) || DirectMessageState.ActiveConversationUserId is null)
+            return;
+
+        var recipientId = DirectMessageState.ActiveConversationUserId.Value;
+        MessageText = string.Empty;
+
+        if (ChatHub.IsConnected)
+        {
+            await ChatHub.SendDirectMessageAsync(recipientId, content);
+            await ChatHub.DirectMessageStoppedTypingAsync(recipientId);
+        }
+    }
+
+    private async Task SendTypingSignalAsync()
+    {
+        if (DirectMessageState.ActiveConversationUserId is null || !ChatHub.IsConnected)
+            return;
+
+        var now = DateTime.UtcNow;
+        if ((now - _lastTypingSignal) < TypingDebounceInterval)
+            return;
+
+        _lastTypingSignal = now;
+        await ChatHub.DirectMessageTypingAsync(DirectMessageState.ActiveConversationUserId.Value);
+    }
+
+    private string FormatTypingText()
+    {
+        var users = DirectMessageState.TypingDisplayNames.ToList();
+
+        return users.Count switch
+        {
+            1 => $"{users[0]} is typing...",
+            2 => $"{users[0]} and {users[1]} are typing...",
+            3 => $"{users[0]}, {users[1]}, and {users[2]} are typing...",
+            _ => "Several people are typing..."
+        };
+    }
+
+    public void Dispose()
+    {
+        DirectMessageState.OnChange -= StateHasChanged;
+    }
+}

--- a/src/HotBox.Client/Components/DirectMessageList.razor
+++ b/src/HotBox.Client/Components/DirectMessageList.razor
@@ -1,0 +1,48 @@
+@using HotBox.Client.State
+@using HotBox.Client.Models
+@using HotBox.Client.Services
+@inject DirectMessageState DirectMessageState
+@inject ApiClient Api
+@inject NavigationManager Navigation
+@implements IDisposable
+
+@foreach (var conversation in DirectMessageState.Conversations)
+{
+    var isActive = DirectMessageState.ActiveConversationUserId == conversation.UserId;
+    <button class="channel-tab @(isActive ? "active" : "")"
+            @onclick="() => SelectConversation(conversation)">
+        <span class="tab-hash">@@</span>
+        <span>@conversation.DisplayName</span>
+        @if (conversation.UnreadCount > 0)
+        {
+            <span class="unread-badge">@conversation.UnreadCount</span>
+        }
+    </button>
+}
+
+@code {
+    private bool _loaded;
+
+    protected override async Task OnInitializedAsync()
+    {
+        DirectMessageState.OnChange += StateHasChanged;
+
+        if (!_loaded)
+        {
+            _loaded = true;
+            var conversations = await Api.GetConversationsAsync();
+            DirectMessageState.SetConversations(conversations);
+        }
+    }
+
+    private void SelectConversation(ConversationSummaryResponse conversation)
+    {
+        DirectMessageState.SetActiveConversation(conversation.UserId, conversation.DisplayName);
+        Navigation.NavigateTo($"/dm/{conversation.UserId}");
+    }
+
+    public void Dispose()
+    {
+        DirectMessageState.OnChange -= StateHasChanged;
+    }
+}

--- a/src/HotBox.Client/Components/DirectMessageMessageList.razor
+++ b/src/HotBox.Client/Components/DirectMessageMessageList.razor
@@ -1,0 +1,105 @@
+@using HotBox.Client.State
+@using HotBox.Client.Models
+@inject DirectMessageState DirectMessageState
+@implements IDisposable
+
+<div class="messages-area">
+    <div class="messages-container">
+        @if (DirectMessageState.ActiveConversationUserId is not null)
+        {
+            <div class="channel-welcome">
+                <h2>@@ @DirectMessageState.ActiveConversationDisplayName</h2>
+                <p>
+                    This is the beginning of your conversation with @DirectMessageState.ActiveConversationDisplayName.
+                </p>
+            </div>
+        }
+
+        @if (DirectMessageState.IsLoadingMessages)
+        {
+            <div class="page-placeholder">
+                <p>Loading messages...</p>
+            </div>
+        }
+        else
+        {
+            string? lastAuthor = null;
+            DateTime? lastTime = null;
+
+            @foreach (var msg in DirectMessageState.Messages)
+            {
+                var isNewAuthor = msg.SenderDisplayName != lastAuthor
+                    || (lastTime.HasValue && (msg.CreatedAtUtc - lastTime.Value).TotalMinutes > 5);
+
+                if (isNewAuthor)
+                {
+                    <div class="message-group new-author">
+                        <div class="msg-avatar" style="background: @GetAvatarColor(msg.SenderDisplayName);">
+                            @GetInitials(msg.SenderDisplayName)
+                        </div>
+                        <div class="msg-content">
+                            <div class="msg-header">
+                                <span class="msg-author" style="color: @GetAvatarColor(msg.SenderDisplayName);">
+                                    @msg.SenderDisplayName
+                                </span>
+                                <span class="msg-timestamp">@FormatTime(msg.CreatedAtUtc)</span>
+                            </div>
+                            <div class="msg-body">@msg.Content</div>
+                        </div>
+                    </div>
+                }
+                else
+                {
+                    <div class="message-group">
+                        <div style="width: 34px; flex-shrink: 0;"></div>
+                        <div class="msg-content">
+                            <div class="msg-body">@msg.Content</div>
+                        </div>
+                    </div>
+                }
+
+                lastAuthor = msg.SenderDisplayName;
+                lastTime = msg.CreatedAtUtc;
+            }
+        }
+    </div>
+</div>
+
+@code {
+    protected override void OnInitialized()
+    {
+        DirectMessageState.OnChange += StateHasChanged;
+    }
+
+    private static string FormatTime(DateTime utc)
+    {
+        var local = utc.ToLocalTime();
+        return local.ToString("h:mm tt");
+    }
+
+    private static string GetAvatarColor(string name)
+    {
+        int hash = 0;
+        foreach (char c in name)
+        {
+            hash = c + ((hash << 5) - hash);
+        }
+        int hue = Math.Abs(hash) % 360;
+        return $"hsl({hue}, 32%, 38%)";
+    }
+
+    private static string GetInitials(string displayName)
+    {
+        var parts = displayName.Split(' ', StringSplitOptions.RemoveEmptyEntries);
+        if (parts.Length >= 2)
+            return $"{parts[0][0]}{parts[1][0]}".ToUpper();
+        return displayName.Length >= 2
+            ? displayName[..2].ToUpper()
+            : displayName.ToUpper();
+    }
+
+    public void Dispose()
+    {
+        DirectMessageState.OnChange -= StateHasChanged;
+    }
+}

--- a/src/HotBox.Client/DependencyInjection/ClientServiceExtensions.cs
+++ b/src/HotBox.Client/DependencyInjection/ClientServiceExtensions.cs
@@ -10,6 +10,7 @@ public static class ClientServiceExtensions
     {
         services.AddScoped<AuthState>();
         services.AddScoped<ChannelState>();
+        services.AddScoped<DirectMessageState>();
         services.AddScoped<AppState>();
         services.AddScoped<ChatHubService>();
 

--- a/src/HotBox.Client/Layout/MainLayout.razor
+++ b/src/HotBox.Client/Layout/MainLayout.razor
@@ -27,7 +27,7 @@
             }
             else
             {
-                @* DM tabs will be added later *@
+                <DirectMessageList />
             }
         </div>
 

--- a/src/HotBox.Client/Models/ConversationSummaryResponse.cs
+++ b/src/HotBox.Client/Models/ConversationSummaryResponse.cs
@@ -1,0 +1,14 @@
+namespace HotBox.Client.Models;
+
+public class ConversationSummaryResponse
+{
+    public Guid UserId { get; set; }
+
+    public string DisplayName { get; set; } = string.Empty;
+
+    public string LastMessageContent { get; set; } = string.Empty;
+
+    public DateTime LastMessageAtUtc { get; set; }
+
+    public int UnreadCount { get; set; }
+}

--- a/src/HotBox.Client/Models/DirectMessageResponse.cs
+++ b/src/HotBox.Client/Models/DirectMessageResponse.cs
@@ -1,0 +1,18 @@
+namespace HotBox.Client.Models;
+
+public class DirectMessageResponse
+{
+    public Guid Id { get; set; }
+
+    public string Content { get; set; } = string.Empty;
+
+    public Guid SenderId { get; set; }
+
+    public string SenderDisplayName { get; set; } = string.Empty;
+
+    public Guid RecipientId { get; set; }
+
+    public DateTime CreatedAtUtc { get; set; }
+
+    public DateTime? ReadAtUtc { get; set; }
+}

--- a/src/HotBox.Client/Pages/DirectMessagePage.razor
+++ b/src/HotBox.Client/Pages/DirectMessagePage.razor
@@ -1,13 +1,111 @@
 @page "/dm/{UserId:guid}"
+@using HotBox.Client.State
+@using HotBox.Client.Services
+@using HotBox.Client.Models
+@inject DirectMessageState DirectMessageState
+@inject AuthState AuthState
+@inject ApiClient Api
+@inject ChatHubService ChatHub
+@implements IDisposable
 
-<PageTitle>HotBox - Direct Message</PageTitle>
+<PageTitle>HotBox - DM with @(DirectMessageState.ActiveConversationDisplayName ?? "User")</PageTitle>
 
-<div class="page-placeholder">
-    <h2>Direct Message</h2>
-    <p>Conversation with user @UserId will be rendered here. This is a shell placeholder.</p>
-</div>
+<DirectMessageMessageList />
+<DirectMessageInput />
 
 @code {
     [Parameter]
     public Guid UserId { get; set; }
+
+    private Guid _currentUserId;
+
+    protected override void OnInitialized()
+    {
+        // Set the current user ID on state so AddMessage can determine the "other user"
+        if (AuthState.CurrentUser is not null)
+        {
+            DirectMessageState.SetCurrentUserId(AuthState.CurrentUser.Id);
+        }
+
+        // Subscribe to real-time DM events
+        ChatHub.OnDirectMessageReceived += HandleDirectMessageReceived;
+        ChatHub.OnDirectMessageTyping += HandleDirectMessageTyping;
+        ChatHub.OnDirectMessageStoppedTyping += HandleDirectMessageStoppedTyping;
+    }
+
+    protected override async Task OnParametersSetAsync()
+    {
+        // Avoid reloading if navigating to the same conversation
+        if (_currentUserId == UserId)
+            return;
+
+        _currentUserId = UserId;
+
+        // Set active conversation from the already-loaded conversations list
+        var conversation = DirectMessageState.Conversations.FirstOrDefault(c => c.UserId == UserId);
+        if (conversation is not null)
+        {
+            DirectMessageState.SetActiveConversation(conversation.UserId, conversation.DisplayName);
+        }
+        else
+        {
+            // Conversation not in local state; set with userId and a placeholder name
+            DirectMessageState.SetActiveConversation(UserId, "User");
+        }
+
+        // Load messages for this conversation
+        DirectMessageState.SetLoadingMessages(true);
+        try
+        {
+            var messages = await Api.GetDirectMessagesAsync(UserId);
+            DirectMessageState.SetMessages(messages);
+        }
+        finally
+        {
+            DirectMessageState.SetLoadingMessages(false);
+        }
+    }
+
+    private void HandleDirectMessageReceived(DirectMessageResponse message)
+    {
+        // Only add to state if this message belongs to the active conversation
+        if (DirectMessageState.ActiveConversationUserId.HasValue &&
+            (message.SenderId == DirectMessageState.ActiveConversationUserId.Value ||
+             message.RecipientId == DirectMessageState.ActiveConversationUserId.Value))
+        {
+            DirectMessageState.AddMessage(message);
+            InvokeAsync(StateHasChanged);
+        }
+    }
+
+    private void HandleDirectMessageTyping(Guid senderId, string displayName)
+    {
+        if (DirectMessageState.ActiveConversationUserId.HasValue &&
+            senderId == DirectMessageState.ActiveConversationUserId.Value)
+        {
+            DirectMessageState.AddTypingUser(senderId, displayName);
+            InvokeAsync(StateHasChanged);
+        }
+    }
+
+    private void HandleDirectMessageStoppedTyping(Guid senderId)
+    {
+        if (DirectMessageState.ActiveConversationUserId.HasValue &&
+            senderId == DirectMessageState.ActiveConversationUserId.Value)
+        {
+            DirectMessageState.RemoveTypingUser(senderId);
+            InvokeAsync(StateHasChanged);
+        }
+    }
+
+    public void Dispose()
+    {
+        // Unsubscribe from real-time events
+        ChatHub.OnDirectMessageReceived -= HandleDirectMessageReceived;
+        ChatHub.OnDirectMessageTyping -= HandleDirectMessageTyping;
+        ChatHub.OnDirectMessageStoppedTyping -= HandleDirectMessageStoppedTyping;
+
+        // Clear active conversation when navigating away
+        DirectMessageState.ClearActiveConversation();
+    }
 }

--- a/src/HotBox.Client/Services/ApiClient.cs
+++ b/src/HotBox.Client/Services/ApiClient.cs
@@ -103,6 +103,37 @@ public class ApiClient
         return await GetAsync<MessageResponse>($"api/messages/{id}", ct);
     }
 
+    // ── Direct Messages ────────────────────────────────────────────────
+
+    public async Task<List<ConversationSummaryResponse>> GetConversationsAsync(CancellationToken ct = default)
+    {
+        return await GetAsync<List<ConversationSummaryResponse>>("api/dm", ct) ?? new List<ConversationSummaryResponse>();
+    }
+
+    public async Task<List<DirectMessageResponse>> GetDirectMessagesAsync(
+        Guid userId,
+        DateTime? before = null,
+        int limit = 50,
+        CancellationToken ct = default)
+    {
+        var url = $"api/dm/{userId}?limit={limit}";
+        if (before.HasValue)
+        {
+            url += $"&before={before.Value:O}";
+        }
+
+        return await GetAsync<List<DirectMessageResponse>>(url, ct) ?? new List<DirectMessageResponse>();
+    }
+
+    public async Task<DirectMessageResponse?> SendDirectMessageAsync(
+        Guid userId,
+        string content,
+        CancellationToken ct = default)
+    {
+        var request = new { Content = content };
+        return await PostAsync<DirectMessageResponse>($"api/dm/{userId}", request, ct);
+    }
+
     // ── HTTP Helpers ────────────────────────────────────────────────────
 
     private void SetAuthHeader()

--- a/src/HotBox.Client/State/AppState.cs
+++ b/src/HotBox.Client/State/AppState.cs
@@ -2,18 +2,22 @@ namespace HotBox.Client.State;
 
 public class AppState
 {
-    public AppState(AuthState auth, ChannelState channel)
+    public AppState(AuthState auth, ChannelState channel, DirectMessageState directMessage)
     {
         Auth = auth;
         Channel = channel;
+        DirectMessage = directMessage;
 
         Auth.OnChange += NotifyStateChanged;
         Channel.OnChange += NotifyStateChanged;
+        DirectMessage.OnChange += NotifyStateChanged;
     }
 
     public AuthState Auth { get; }
 
     public ChannelState Channel { get; }
+
+    public DirectMessageState DirectMessage { get; }
 
     public bool IsConnected { get; private set; }
 

--- a/src/HotBox.Client/State/DirectMessageState.cs
+++ b/src/HotBox.Client/State/DirectMessageState.cs
@@ -1,0 +1,118 @@
+using HotBox.Client.Models;
+
+namespace HotBox.Client.State;
+
+public class DirectMessageState
+{
+    public List<ConversationSummaryResponse> Conversations { get; private set; } = new();
+
+    public Guid? ActiveConversationUserId { get; private set; }
+
+    public string? ActiveConversationDisplayName { get; private set; }
+
+    public List<DirectMessageResponse> Messages { get; private set; } = new();
+
+    /// <summary>Maps userId to displayName for users currently typing in the active DM conversation.</summary>
+    public Dictionary<Guid, string> TypingUsers { get; private set; } = new();
+
+    /// <summary>Display names of currently typing users, for UI consumption.</summary>
+    public IReadOnlyList<string> TypingDisplayNames => TypingUsers.Values.ToList();
+
+    public bool IsLoadingMessages { get; private set; }
+
+    public Guid? CurrentUserId { get; private set; }
+
+    public void SetCurrentUserId(Guid userId) { CurrentUserId = userId; }
+
+    public event Action? OnChange;
+
+    public void SetConversations(List<ConversationSummaryResponse> conversations)
+    {
+        Conversations = conversations;
+        NotifyStateChanged();
+    }
+
+    public void SetActiveConversation(Guid userId, string displayName)
+    {
+        ActiveConversationUserId = userId;
+        ActiveConversationDisplayName = displayName;
+        Messages = new();
+        TypingUsers = new();
+        NotifyStateChanged();
+    }
+
+    public void ClearActiveConversation()
+    {
+        ActiveConversationUserId = null;
+        ActiveConversationDisplayName = null;
+        Messages = new();
+        TypingUsers = new();
+        NotifyStateChanged();
+    }
+
+    public void SetMessages(List<DirectMessageResponse> messages)
+    {
+        Messages = messages;
+        NotifyStateChanged();
+    }
+
+    public void AddMessage(DirectMessageResponse message)
+    {
+        Messages.Add(message);
+
+        // Remove the sender from typing users when their message arrives
+        TypingUsers.Remove(message.SenderId);
+
+        // Determine the other user in this conversation
+        var otherUserId = message.SenderId == CurrentUserId ? message.RecipientId : message.SenderId;
+
+        // Update the conversation summary and move it to the top
+        var conversation = Conversations.FirstOrDefault(c => c.UserId == otherUserId);
+        if (conversation is not null)
+        {
+            conversation.LastMessageContent = message.Content;
+            conversation.LastMessageAtUtc = message.CreatedAtUtc;
+            Conversations.Remove(conversation);
+            Conversations.Insert(0, conversation);
+        }
+
+        NotifyStateChanged();
+    }
+
+    public void PrependMessages(List<DirectMessageResponse> olderMessages)
+    {
+        Messages.InsertRange(0, olderMessages);
+        NotifyStateChanged();
+    }
+
+    public void AddTypingUser(Guid userId, string displayName)
+    {
+        TypingUsers[userId] = displayName;
+        NotifyStateChanged();
+    }
+
+    public void RemoveTypingUser(Guid userId)
+    {
+        if (TypingUsers.Remove(userId))
+        {
+            NotifyStateChanged();
+        }
+    }
+
+    public void ClearTypingUsers()
+    {
+        if (TypingUsers.Count > 0)
+        {
+            TypingUsers.Clear();
+            NotifyStateChanged();
+        }
+    }
+
+    public void SetLoadingMessages(bool loading)
+    {
+        IsLoadingMessages = loading;
+        NotifyStateChanged();
+    }
+
+    private void NotifyStateChanged() => OnChange?.Invoke();
+}

--- a/src/HotBox.Core/Interfaces/IDirectMessageService.cs
+++ b/src/HotBox.Core/Interfaces/IDirectMessageService.cs
@@ -1,0 +1,13 @@
+using HotBox.Core.Entities;
+using HotBox.Core.Models;
+
+namespace HotBox.Core.Interfaces;
+
+public interface IDirectMessageService
+{
+    Task<DirectMessage> SendAsync(Guid senderId, Guid recipientId, string content, CancellationToken ct = default);
+
+    Task<IReadOnlyList<DirectMessage>> GetConversationAsync(Guid userId, Guid otherUserId, DateTime? before = null, int limit = 50, CancellationToken ct = default);
+
+    Task<IReadOnlyList<ConversationSummary>> GetConversationsAsync(Guid userId, CancellationToken ct = default);
+}

--- a/src/HotBox.Infrastructure/DependencyInjection/InfrastructureServiceExtensions.cs
+++ b/src/HotBox.Infrastructure/DependencyInjection/InfrastructureServiceExtensions.cs
@@ -92,6 +92,7 @@ public static class InfrastructureServiceExtensions
         services.AddScoped<IInviteService, InviteService>();
         services.AddScoped<IChannelService, ChannelService>();
         services.AddScoped<IMessageService, MessageService>();
+        services.AddScoped<IDirectMessageService, DirectMessageService>();
 
         return services;
     }

--- a/src/HotBox.Infrastructure/Repositories/DirectMessageRepository.cs
+++ b/src/HotBox.Infrastructure/Repositories/DirectMessageRepository.cs
@@ -24,6 +24,7 @@ public class DirectMessageRepository : IDirectMessageRepository
     {
         var query = _context.DirectMessages
             .AsNoTracking()
+            .Include(dm => dm.Sender)
             .Where(dm =>
                 (dm.SenderId == userId && dm.RecipientId == otherUserId) ||
                 (dm.SenderId == otherUserId && dm.RecipientId == userId));
@@ -76,6 +77,11 @@ public class DirectMessageRepository : IDirectMessageRepository
     {
         _context.DirectMessages.Add(message);
         await _context.SaveChangesAsync(ct);
-        return message;
+
+        // Re-query with navigation properties included
+        return await _context.DirectMessages
+            .AsNoTracking()
+            .Include(dm => dm.Sender)
+            .FirstAsync(dm => dm.Id == message.Id, ct);
     }
 }

--- a/src/HotBox.Infrastructure/Services/DirectMessageService.cs
+++ b/src/HotBox.Infrastructure/Services/DirectMessageService.cs
@@ -1,0 +1,77 @@
+using HotBox.Core.Entities;
+using HotBox.Core.Interfaces;
+using HotBox.Core.Models;
+using Microsoft.AspNetCore.Identity;
+using Microsoft.Extensions.Logging;
+
+namespace HotBox.Infrastructure.Services;
+
+public class DirectMessageService : IDirectMessageService
+{
+    private readonly IDirectMessageRepository _repository;
+    private readonly UserManager<AppUser> _userManager;
+    private readonly ILogger<DirectMessageService> _logger;
+
+    public DirectMessageService(
+        IDirectMessageRepository repository,
+        UserManager<AppUser> userManager,
+        ILogger<DirectMessageService> logger)
+    {
+        _repository = repository;
+        _userManager = userManager;
+        _logger = logger;
+    }
+
+    public async Task<DirectMessage> SendAsync(
+        Guid senderId,
+        Guid recipientId,
+        string content,
+        CancellationToken ct = default)
+    {
+        if (string.IsNullOrWhiteSpace(content))
+            throw new ArgumentException("Message content cannot be empty.", nameof(content));
+
+        if (senderId == recipientId)
+            throw new ArgumentException("Cannot send a direct message to yourself.");
+
+        var sender = await _userManager.FindByIdAsync(senderId.ToString())
+            ?? throw new KeyNotFoundException($"Sender {senderId} not found.");
+
+        var recipient = await _userManager.FindByIdAsync(recipientId.ToString())
+            ?? throw new KeyNotFoundException($"Recipient {recipientId} not found.");
+
+        var message = new DirectMessage
+        {
+            Id = Guid.NewGuid(),
+            Content = content,
+            SenderId = senderId,
+            RecipientId = recipientId,
+            CreatedAtUtc = DateTime.UtcNow,
+        };
+
+        var created = await _repository.CreateAsync(message, ct);
+
+        _logger.LogInformation(
+            "Direct message {MessageId} sent from user {SenderId} to user {RecipientId}",
+            created.Id, senderId, recipientId);
+
+        return created;
+    }
+
+    public async Task<IReadOnlyList<DirectMessage>> GetConversationAsync(
+        Guid userId,
+        Guid otherUserId,
+        DateTime? before = null,
+        int limit = 50,
+        CancellationToken ct = default)
+    {
+        return await _repository.GetConversationAsync(userId, otherUserId, before, limit, ct);
+    }
+
+    public async Task<IReadOnlyList<ConversationSummary>> GetConversationsAsync(
+        Guid userId,
+        CancellationToken ct = default)
+    {
+        return await _repository.GetConversationsAsync(userId, ct);
+    }
+}


### PR DESCRIPTION
## Summary

- **Service layer**: `IDirectMessageService` + `DirectMessageService` with user validation, self-messaging prevention, and cursor-based pagination
- **SignalR real-time**: `ChatHub` extended with `SendDirectMessage`, `DirectMessageTyping`, `DirectMessageStoppedTyping` using user-based messaging (`Clients.User()`)
- **REST API**: `DirectMessagesController` with `GET /api/dm` (conversation list), `GET /api/dm/{userId}` (messages with pagination), `POST /api/dm/{userId}` (send)
- **Blazor WASM UI**: `DirectMessageList` sidebar component, `DirectMessagePage` with real-time event subscriptions, `DirectMessageMessageList` + `DirectMessageInput` components, `DirectMessageState` for state management
- **Infrastructure**: DTOs in both Application and Client layers, DI registration, eager loading fix for `DirectMessageRepository`

## Test plan

- [ ] Verify `GET /api/dm` returns conversation list for authenticated user
- [ ] Verify `GET /api/dm/{userId}?before=...&limit=50` returns paginated messages
- [ ] Verify `POST /api/dm/{userId}` creates and returns a DM
- [ ] Verify `POST /api/dm/{userId}` rejects empty content (400) and non-existent users (404)
- [ ] Verify self-messaging returns 400
- [ ] Verify real-time DM delivery: sender and recipient both receive `ReceiveDirectMessage` via SignalR
- [ ] Verify typing indicators work for DMs
- [ ] Verify DM list appears in sidebar when switching to DMs section
- [ ] Verify clicking a DM conversation navigates to `/dm/{userId}` and loads message history
- [ ] Verify new DMs appear in real-time without page refresh

Closes #4
Closes #41
Closes #42
Closes #43
Closes #44

🤖 Generated with [Claude Code](https://claude.com/claude-code)