### PR TITLE
feat: implement message search with provider-aware FTS (#5)

### DIFF
--- a/src/HotBox.Application/Controllers/SearchController.cs
+++ b/src/HotBox.Application/Controllers/SearchController.cs
@@ -1,0 +1,121 @@
+using HotBox.Application.Models;
+using HotBox.Core.Interfaces;
+using HotBox.Core.Models;
+using HotBox.Core.Options;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.Extensions.Options;
+
+namespace HotBox.Application.Controllers;
+
+[ApiController]
+[Route("api/search")]
+[Authorize]
+public class SearchController : ControllerBase
+{
+    private readonly ISearchService _searchService;
+    private readonly ILogger<SearchController> _logger;
+    private readonly SearchOptions _options;
+
+    public SearchController(
+        ISearchService searchService,
+        ILogger<SearchController> logger,
+        IOptions<SearchOptions> options)
+    {
+        _searchService = searchService;
+        _logger = logger;
+        _options = options.Value;
+    }
+
+    [HttpGet("messages")]
+    public async Task<IActionResult> SearchMessages(
+        [FromQuery(Name = "q")] string? query,
+        [FromQuery] Guid? channelId = null,
+        [FromQuery] string? cursor = null,
+        [FromQuery] int? limit = null,
+        CancellationToken ct = default)
+    {
+        if (string.IsNullOrWhiteSpace(query))
+        {
+            return BadRequest(new { error = "Query parameter 'q' is required." });
+        }
+
+        if (query.Length < _options.MinQueryLength)
+        {
+            return BadRequest(new { error = $"Query must be at least {_options.MinQueryLength} characters." });
+        }
+
+        var effectiveLimit = limit ?? _options.DefaultLimit;
+        if (effectiveLimit is < 1 or > 100)
+        {
+            return BadRequest(new { error = "Limit must be between 1 and 100." });
+        }
+
+        var searchQuery = new SearchQuery
+        {
+            QueryText = query,
+            ChannelId = channelId,
+            Cursor = cursor,
+            Limit = effectiveLimit,
+        };
+
+        _logger.LogInformation(
+            "Search request: Query={Query}, ChannelId={ChannelId}, Cursor={Cursor}, Limit={Limit}",
+            query, channelId, cursor, effectiveLimit);
+
+        var result = await _searchService.SearchMessagesAsync(searchQuery, ct);
+
+        var response = new SearchResultResponse
+        {
+            Items = result.Items.Select(item => new SearchResultItemResponse
+            {
+                MessageId = item.MessageId,
+                Snippet = item.Snippet,
+                ChannelId = item.ChannelId,
+                ChannelName = item.ChannelName,
+                AuthorId = item.AuthorId,
+                AuthorDisplayName = item.AuthorDisplayName,
+                CreatedAtUtc = item.CreatedAtUtc,
+                RelevanceScore = item.RelevanceScore,
+            }).ToList(),
+            Cursor = result.Cursor,
+            TotalEstimate = result.TotalEstimate,
+        };
+
+        return Ok(response);
+    }
+
+    [HttpGet("status")]
+    public IActionResult GetStatus()
+    {
+        var response = new SearchStatusResponse
+        {
+            IsFullTextSearchAvailable = _searchService.IsFullTextSearchAvailable,
+            ProviderName = _searchService.ProviderName,
+        };
+
+        return Ok(response);
+    }
+
+    [HttpPost("reindex")]
+    [Authorize(Roles = "Admin")]
+    public async Task<IActionResult> Reindex(CancellationToken ct)
+    {
+        _logger.LogInformation("Admin-initiated search reindex started using provider {ProviderName}",
+            _searchService.ProviderName);
+
+        try
+        {
+            await _searchService.ReindexAsync(ct);
+
+            _logger.LogInformation("Admin-initiated search reindex completed successfully");
+
+            return Ok(new { message = "Search index rebuild completed.", provider = _searchService.ProviderName });
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Search reindex failed");
+            return StatusCode(500, new { error = "Search reindex failed. Check server logs for details." });
+        }
+    }
+}

--- a/src/HotBox.Application/Models/SearchResultItemResponse.cs
+++ b/src/HotBox.Application/Models/SearchResultItemResponse.cs
@@ -1,0 +1,20 @@
+namespace HotBox.Application.Models;
+
+public class SearchResultItemResponse
+{
+    public Guid MessageId { get; set; }
+
+    public string Snippet { get; set; } = string.Empty;
+
+    public Guid ChannelId { get; set; }
+
+    public string ChannelName { get; set; } = string.Empty;
+
+    public Guid AuthorId { get; set; }
+
+    public string AuthorDisplayName { get; set; } = string.Empty;
+
+    public DateTime CreatedAtUtc { get; set; }
+
+    public double RelevanceScore { get; set; }
+}

--- a/src/HotBox.Application/Models/SearchResultResponse.cs
+++ b/src/HotBox.Application/Models/SearchResultResponse.cs
@@ -1,0 +1,10 @@
+namespace HotBox.Application.Models;
+
+public class SearchResultResponse
+{
+    public IReadOnlyList<SearchResultItemResponse> Items { get; set; } = [];
+
+    public string? Cursor { get; set; }
+
+    public int TotalEstimate { get; set; }
+}

--- a/src/HotBox.Application/Models/SearchStatusResponse.cs
+++ b/src/HotBox.Application/Models/SearchStatusResponse.cs
@@ -1,0 +1,8 @@
+namespace HotBox.Application.Models;
+
+public class SearchStatusResponse
+{
+    public bool IsFullTextSearchAvailable { get; set; }
+
+    public string ProviderName { get; set; } = string.Empty;
+}

--- a/src/HotBox.Application/Program.cs
+++ b/src/HotBox.Application/Program.cs
@@ -1,6 +1,7 @@
 using HotBox.Application.DependencyInjection;
 using HotBox.Application.Hubs;
 using HotBox.Core.Enums;
+using HotBox.Core.Interfaces;
 using HotBox.Infrastructure.Data;
 using HotBox.Infrastructure.Data.Seeding;
 using HotBox.Infrastructure.DependencyInjection;
@@ -35,6 +36,13 @@ try
         using var scope = app.Services.CreateScope();
         var db = scope.ServiceProvider.GetRequiredService<HotBoxDbContext>();
         db.Database.Migrate();
+    }
+
+    // Initialize search indexes (FTS tables, GIN indexes, etc.)
+    {
+        using var scope = app.Services.CreateScope();
+        var searchService = scope.ServiceProvider.GetRequiredService<ISearchService>();
+        searchService.InitializeIndexAsync(CancellationToken.None).GetAwaiter().GetResult();
     }
 
     // Configure the HTTP request pipeline.

--- a/src/HotBox.Client/Components/SearchOverlay.razor
+++ b/src/HotBox.Client/Components/SearchOverlay.razor
@@ -1,0 +1,289 @@
+@inject SearchState SearchState
+@inject ChannelState ChannelState
+@inject ApiClient ApiClient
+@inject NavigationManager Navigation
+@inject IJSRuntime JS
+@implements IAsyncDisposable
+
+@if (SearchState.IsOpen)
+{
+    <div class="search-overlay-backdrop" @onclick="HandleBackdropClick">
+        <div class="search-overlay" @onclick:stopPropagation="true" @onkeydown="HandleKeyDown">
+            <!-- Search input -->
+            <div class="search-input-wrapper">
+                <svg class="search-input-icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+                    <circle cx="11" cy="11" r="8"></circle>
+                    <line x1="21" y1="21" x2="16.65" y2="16.65"></line>
+                </svg>
+                <input @ref="_searchInput"
+                       type="text"
+                       class="search-input"
+                       placeholder="Search messages... (Ctrl+K)"
+                       value="@SearchState.Query"
+                       @oninput="HandleInput"
+                       @onkeydown="HandleKeyDown" />
+                @if (SearchState.IsSearching)
+                {
+                    <div class="search-spinner">
+                        <div class="spinner"></div>
+                    </div>
+                }
+                <div class="search-shortcut-hint">
+                    <kbd>ESC</kbd>
+                </div>
+            </div>
+
+            <!-- Channel filter -->
+            <div class="search-filter-bar">
+                <select class="search-channel-filter" @onchange="HandleChannelFilterChange">
+                    <option value="">All channels</option>
+                    @foreach (var channel in ChannelState.Channels.Where(c => c.Type == HotBox.Core.Enums.ChannelType.Text).OrderBy(c => c.SortOrder))
+                    {
+                        <option value="@channel.Id" selected="@(_filterChannelId == channel.Id)"># @channel.Name</option>
+                    }
+                </select>
+                @if (SearchState.TotalEstimate > 0)
+                {
+                    <span class="search-result-count">@SearchState.TotalEstimate results</span>
+                }
+            </div>
+
+            <!-- Results -->
+            <div class="search-results">
+                @if (string.IsNullOrWhiteSpace(SearchState.Query) || SearchState.Query.Length < 2)
+                {
+                    <div class="search-empty-state">
+                        <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round" width="32" height="32">
+                            <circle cx="11" cy="11" r="8"></circle>
+                            <line x1="21" y1="21" x2="16.65" y2="16.65"></line>
+                        </svg>
+                        <span>Type to search messages</span>
+                    </div>
+                }
+                else if (!SearchState.IsSearching && SearchState.Results.Count == 0 && _hasSearched)
+                {
+                    <div class="search-empty-state">
+                        <span>No results found</span>
+                    </div>
+                }
+                else
+                {
+                    @for (var i = 0; i < SearchState.Results.Count; i++)
+                    {
+                        var index = i;
+                        var item = SearchState.Results[i];
+                        <button class="search-result-item @(index == _selectedIndex ? "selected" : "")"
+                                @onclick="() => JumpToMessage(item)"
+                                @onmouseenter="() => _selectedIndex = index">
+                            <div class="search-result-header">
+                                <span class="search-result-author">@item.AuthorDisplayName</span>
+                                <span class="search-result-channel"># @item.ChannelName</span>
+                                <span class="search-result-time">@FormatRelativeTime(item.CreatedAtUtc)</span>
+                            </div>
+                            <div class="search-result-snippet">@((MarkupString)item.Snippet)</div>
+                        </button>
+                    }
+                }
+            </div>
+        </div>
+    </div>
+}
+
+@code {
+    private ElementReference _searchInput;
+    private DotNetObjectReference<SearchOverlay>? _dotNetRef;
+    private CancellationTokenSource? _debounceCts;
+    private int _selectedIndex;
+    private bool _hasSearched;
+    private Guid? _filterChannelId;
+
+    protected override async Task OnInitializedAsync()
+    {
+        SearchState.OnChange += HandleStateChanged;
+
+        _dotNetRef = DotNetObjectReference.Create(this);
+        await JS.InvokeVoidAsync("searchInterop.register", _dotNetRef);
+    }
+
+    protected override async Task OnAfterRenderAsync(bool firstRender)
+    {
+        if (SearchState.IsOpen)
+        {
+            try
+            {
+                await JS.InvokeVoidAsync("searchInterop.focusElement", _searchInput);
+            }
+            catch
+            {
+                // Element may not be in DOM yet on first render
+            }
+        }
+    }
+
+    [JSInvokable]
+    public void OnSearchShortcut()
+    {
+        if (SearchState.IsOpen)
+        {
+            CloseSearch();
+        }
+        else
+        {
+            SearchState.Open();
+        }
+
+        StateHasChanged();
+    }
+
+    private void HandleStateChanged()
+    {
+        InvokeAsync(StateHasChanged);
+    }
+
+    private void HandleBackdropClick()
+    {
+        CloseSearch();
+    }
+
+    private async Task HandleInput(ChangeEventArgs e)
+    {
+        var query = e.Value?.ToString() ?? string.Empty;
+        SearchState.SetQuery(query);
+        _selectedIndex = 0;
+
+        // Cancel any pending debounce
+        _debounceCts?.Cancel();
+        _debounceCts?.Dispose();
+
+        if (query.Length < 2)
+        {
+            _hasSearched = false;
+            SearchState.SetResults(new(), 0, null);
+            SearchState.SetSearching(false);
+            return;
+        }
+
+        _debounceCts = new CancellationTokenSource();
+        var ct = _debounceCts.Token;
+
+        try
+        {
+            await Task.Delay(300, ct);
+            await PerformSearchAsync(query, ct);
+        }
+        catch (TaskCanceledException)
+        {
+            // Debounce cancelled — expected
+        }
+    }
+
+    private async Task PerformSearchAsync(string query, CancellationToken ct)
+    {
+        SearchState.SetSearching(true);
+
+        var result = await ApiClient.SearchMessagesAsync(query, _filterChannelId, null, 20, ct);
+
+        if (ct.IsCancellationRequested) return;
+
+        _hasSearched = true;
+
+        if (result is not null)
+        {
+            SearchState.SetResults(result.Items, result.TotalEstimate, result.Cursor);
+        }
+        else
+        {
+            SearchState.SetResults(new(), 0, null);
+        }
+
+        SearchState.SetSearching(false);
+    }
+
+    private async Task HandleChannelFilterChange(ChangeEventArgs e)
+    {
+        var value = e.Value?.ToString();
+        _filterChannelId = string.IsNullOrEmpty(value) ? null : Guid.Parse(value);
+        _selectedIndex = 0;
+
+        if (SearchState.Query.Length >= 2)
+        {
+            _debounceCts?.Cancel();
+            _debounceCts?.Dispose();
+            _debounceCts = new CancellationTokenSource();
+            await PerformSearchAsync(SearchState.Query, _debounceCts.Token);
+        }
+    }
+
+    private void HandleKeyDown(KeyboardEventArgs e)
+    {
+        switch (e.Key)
+        {
+            case "Escape":
+                CloseSearch();
+                break;
+            case "ArrowDown":
+                if (SearchState.Results.Count > 0)
+                {
+                    _selectedIndex = (_selectedIndex + 1) % SearchState.Results.Count;
+                }
+                break;
+            case "ArrowUp":
+                if (SearchState.Results.Count > 0)
+                {
+                    _selectedIndex = (_selectedIndex - 1 + SearchState.Results.Count) % SearchState.Results.Count;
+                }
+                break;
+            case "Enter":
+                if (SearchState.Results.Count > 0 && _selectedIndex >= 0 && _selectedIndex < SearchState.Results.Count)
+                {
+                    JumpToMessage(SearchState.Results[_selectedIndex]);
+                }
+                break;
+        }
+    }
+
+    private void JumpToMessage(SearchResultItemModel item)
+    {
+        CloseSearch();
+        Navigation.NavigateTo($"/channels/{item.ChannelId}");
+    }
+
+    private void CloseSearch()
+    {
+        SearchState.Clear();
+        _hasSearched = false;
+        _selectedIndex = 0;
+        _filterChannelId = null;
+        SearchState.Close();
+    }
+
+    private static string FormatRelativeTime(DateTime utcTime)
+    {
+        var diff = DateTime.UtcNow - utcTime;
+
+        if (diff.TotalMinutes < 1) return "just now";
+        if (diff.TotalMinutes < 60) return $"{(int)diff.TotalMinutes}m ago";
+        if (diff.TotalHours < 24) return $"{(int)diff.TotalHours}h ago";
+        if (diff.TotalDays < 2) return "yesterday";
+        if (diff.TotalDays < 7) return $"{(int)diff.TotalDays}d ago";
+        return utcTime.ToLocalTime().ToString("MMM d, yyyy");
+    }
+
+    public async ValueTask DisposeAsync()
+    {
+        SearchState.OnChange -= HandleStateChanged;
+        _debounceCts?.Cancel();
+        _debounceCts?.Dispose();
+
+        try
+        {
+            await JS.InvokeVoidAsync("searchInterop.unregister");
+        }
+        catch
+        {
+            // JS interop may fail during app teardown
+        }
+
+        _dotNetRef?.Dispose();
+    }
+}

--- a/src/HotBox.Client/DependencyInjection/ClientServiceExtensions.cs
+++ b/src/HotBox.Client/DependencyInjection/ClientServiceExtensions.cs
@@ -13,6 +13,7 @@ public static class ClientServiceExtensions
         services.AddScoped<DirectMessageState>();
         services.AddScoped<PresenceState>();
         services.AddScoped<VoiceState>();
+        services.AddScoped<SearchState>();
         services.AddScoped<AppState>();
         services.AddScoped<ChatHubService>();
         services.AddScoped<NotificationService>();

--- a/src/HotBox.Client/Layout/MainLayout.razor
+++ b/src/HotBox.Client/Layout/MainLayout.razor
@@ -11,6 +11,7 @@
 @inject NotificationService NotificationService
 @inject VoiceConnectionManager VoiceConnectionManager
 @inject NavigationManager Navigation
+@inject SearchState SearchState
 @inject ILogger<MainLayout> Logger
 @implements IDisposable
 
@@ -95,7 +96,7 @@
             </div>
 
             <!-- Search -->
-            <button class="topbar-icon-btn" aria-label="Search">
+            <button class="topbar-icon-btn" aria-label="Search" @onclick="OpenSearch">
                 <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
                     <circle cx="11" cy="11" r="8"></circle>
                     <line x1="21" y1="21" x2="16.65" y2="16.65"></line>
@@ -184,6 +185,9 @@
             </div>
         </div>
     }
+
+    <!-- ============ Search Overlay ============ -->
+    <SearchOverlay />
 </div>
 
 @* Click-away overlay for closing dropdowns *@
@@ -284,6 +288,11 @@
         {
             Logger.LogError(ex, "Failed to send heartbeat");
         }
+    }
+
+    private void OpenSearch()
+    {
+        SearchState.Open();
     }
 
     private void NavigateToAdmin()

--- a/src/HotBox.Client/Models/SearchResultItemModel.cs
+++ b/src/HotBox.Client/Models/SearchResultItemModel.cs
@@ -1,0 +1,13 @@
+namespace HotBox.Client.Models;
+
+public class SearchResultItemModel
+{
+    public Guid MessageId { get; set; }
+    public string Snippet { get; set; } = string.Empty;
+    public Guid ChannelId { get; set; }
+    public string ChannelName { get; set; } = string.Empty;
+    public Guid AuthorId { get; set; }
+    public string AuthorDisplayName { get; set; } = string.Empty;
+    public DateTime CreatedAtUtc { get; set; }
+    public double RelevanceScore { get; set; }
+}

--- a/src/HotBox.Client/Models/SearchResultModel.cs
+++ b/src/HotBox.Client/Models/SearchResultModel.cs
@@ -1,0 +1,8 @@
+namespace HotBox.Client.Models;
+
+public class SearchResultModel
+{
+    public List<SearchResultItemModel> Items { get; set; } = new();
+    public string? Cursor { get; set; }
+    public int TotalEstimate { get; set; }
+}

--- a/src/HotBox.Client/Services/ApiClient.cs
+++ b/src/HotBox.Client/Services/ApiClient.cs
@@ -240,6 +240,21 @@ public class ApiClient
         return await PutAsync("api/admin/channels/reorder", request, ct);
     }
 
+    // ── Search ────────────────────────────────────────────────────────────
+
+    public async Task<SearchResultModel?> SearchMessagesAsync(
+        string query,
+        Guid? channelId = null,
+        string? cursor = null,
+        int limit = 20,
+        CancellationToken ct = default)
+    {
+        var url = $"api/search/messages?q={Uri.EscapeDataString(query)}&limit={limit}";
+        if (channelId.HasValue) url += $"&channelId={channelId.Value}";
+        if (cursor is not null) url += $"&cursor={Uri.EscapeDataString(cursor)}";
+        return await GetAsync<SearchResultModel>(url, ct);
+    }
+
     // ── HTTP Helpers ────────────────────────────────────────────────────
 
     private void SetAuthHeader()

--- a/src/HotBox.Client/State/SearchState.cs
+++ b/src/HotBox.Client/State/SearchState.cs
@@ -1,0 +1,59 @@
+using HotBox.Client.Models;
+
+namespace HotBox.Client.State;
+
+public class SearchState
+{
+    public string Query { get; private set; } = string.Empty;
+    public List<SearchResultItemModel> Results { get; private set; } = new();
+    public bool IsSearching { get; private set; }
+    public bool IsOpen { get; private set; }
+    public int TotalEstimate { get; private set; }
+    public string? Cursor { get; private set; }
+
+    public event Action? OnChange;
+
+    public void Open()
+    {
+        IsOpen = true;
+        NotifyStateChanged();
+    }
+
+    public void Close()
+    {
+        IsOpen = false;
+        NotifyStateChanged();
+    }
+
+    public void SetResults(List<SearchResultItemModel> results, int totalEstimate, string? cursor)
+    {
+        Results = results;
+        TotalEstimate = totalEstimate;
+        Cursor = cursor;
+        NotifyStateChanged();
+    }
+
+    public void SetSearching(bool searching)
+    {
+        IsSearching = searching;
+        NotifyStateChanged();
+    }
+
+    public void SetQuery(string query)
+    {
+        Query = query;
+        NotifyStateChanged();
+    }
+
+    public void Clear()
+    {
+        Query = string.Empty;
+        Results = new();
+        IsSearching = false;
+        TotalEstimate = 0;
+        Cursor = null;
+        NotifyStateChanged();
+    }
+
+    private void NotifyStateChanged() => OnChange?.Invoke();
+}

--- a/src/HotBox.Client/wwwroot/css/app.css
+++ b/src/HotBox.Client/wwwroot/css/app.css
@@ -2546,3 +2546,234 @@ input, textarea {
   font-size: 12px;
   color: var(--text-secondary);
 }
+
+/* ========================================
+   Search Overlay
+   ======================================== */
+.search-overlay-backdrop {
+  position: fixed;
+  inset: 0;
+  background: rgba(0, 0, 0, 0.6);
+  backdrop-filter: blur(4px);
+  display: flex;
+  align-items: flex-start;
+  justify-content: center;
+  padding-top: 10vh;
+  z-index: 200;
+  animation: search-backdrop-in var(--transition-smooth) forwards;
+}
+
+@keyframes search-backdrop-in {
+  from { opacity: 0; }
+  to { opacity: 1; }
+}
+
+.search-overlay {
+  width: 600px;
+  max-width: 90vw;
+  max-height: 500px;
+  background: var(--bg-raised);
+  border: 1px solid var(--border-light);
+  border-radius: var(--radius-lg);
+  box-shadow: var(--shadow-overlay);
+  display: flex;
+  flex-direction: column;
+  overflow: hidden;
+  animation: search-dialog-in var(--transition-smooth) forwards;
+}
+
+@keyframes search-dialog-in {
+  from {
+    opacity: 0;
+    transform: translateY(-8px) scale(0.98);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0) scale(1);
+  }
+}
+
+/* Search input wrapper */
+.search-input-wrapper {
+  display: flex;
+  align-items: center;
+  padding: 14px 18px;
+  border-bottom: 1px solid var(--border-subtle);
+  gap: 10px;
+}
+
+.search-input-icon {
+  width: 18px;
+  height: 18px;
+  color: var(--text-muted);
+  flex-shrink: 0;
+}
+
+.search-overlay .search-input {
+  flex: 1;
+  padding: 0;
+  font-size: 15px;
+  color: var(--text-primary);
+  background: none;
+  border: none;
+  outline: none;
+}
+
+.search-overlay .search-input::placeholder {
+  color: var(--text-muted);
+}
+
+.search-spinner {
+  flex-shrink: 0;
+}
+
+.search-shortcut-hint {
+  flex-shrink: 0;
+}
+
+.search-shortcut-hint kbd {
+  font-family: var(--font-mono);
+  font-size: 10px;
+  font-weight: 500;
+  color: var(--text-muted);
+  background: var(--bg-surface);
+  border: 1px solid var(--border-subtle);
+  border-radius: var(--radius-xs);
+  padding: 2px 6px;
+  line-height: 1;
+}
+
+/* Channel filter bar */
+.search-filter-bar {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  padding: 8px 18px;
+  border-bottom: 1px solid var(--border-subtle);
+}
+
+.search-channel-filter {
+  padding: 5px 28px 5px 10px;
+  background: var(--bg-surface);
+  border: 1px solid var(--border-subtle);
+  border-radius: var(--radius-md);
+  color: var(--text-secondary);
+  font-size: 12px;
+  font-family: inherit;
+  cursor: pointer;
+  appearance: none;
+  background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='10' height='10' fill='none' stroke='%235c5c72' stroke-width='2' stroke-linecap='round' stroke-linejoin='round'%3E%3Cpath d='M2 3.5l3 3 3-3'/%3E%3C/svg%3E");
+  background-repeat: no-repeat;
+  background-position: right 8px center;
+  outline: none;
+  transition: border-color var(--transition-base);
+}
+
+.search-channel-filter:focus {
+  border-color: var(--border-focus);
+}
+
+.search-channel-filter option {
+  background: var(--bg-raised);
+  color: var(--text-primary);
+}
+
+.search-result-count {
+  font-family: var(--font-mono);
+  font-size: 11px;
+  color: var(--text-muted);
+  margin-left: auto;
+}
+
+/* Results list */
+.search-results {
+  flex: 1;
+  overflow-y: auto;
+  padding: 4px;
+}
+
+.search-empty-state {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 10px;
+  padding: 48px 24px;
+  color: var(--text-muted);
+  font-size: 13px;
+  text-align: center;
+}
+
+.search-empty-state svg {
+  opacity: 0.3;
+}
+
+/* Result item */
+.search-result-item {
+  display: block;
+  width: 100%;
+  text-align: left;
+  padding: 10px 14px;
+  border-radius: var(--radius-md);
+  transition: background var(--transition-fast);
+  cursor: pointer;
+  background: none;
+  border: none;
+  color: inherit;
+  font-family: inherit;
+}
+
+.search-result-item:hover,
+.search-result-item.selected {
+  background: var(--bg-hover);
+}
+
+.search-result-item.selected {
+  background: var(--bg-active);
+}
+
+.search-result-header {
+  display: flex;
+  align-items: baseline;
+  gap: 8px;
+  margin-bottom: 4px;
+}
+
+.search-result-author {
+  font-size: 12px;
+  font-weight: 600;
+  color: var(--text-primary);
+}
+
+.search-result-channel {
+  font-family: var(--font-mono);
+  font-size: 10px;
+  font-weight: 500;
+  color: var(--accent);
+  opacity: 0.7;
+}
+
+.search-result-time {
+  font-family: var(--font-mono);
+  font-size: 10px;
+  color: var(--text-faint);
+  margin-left: auto;
+}
+
+.search-result-snippet {
+  font-size: 13px;
+  color: var(--text-secondary);
+  line-height: 1.45;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  display: -webkit-box;
+  -webkit-line-clamp: 2;
+  -webkit-box-orient: vertical;
+}
+
+.search-result-snippet mark {
+  background: rgba(93, 228, 199, 0.18);
+  color: var(--accent-strong);
+  border-radius: 2px;
+  padding: 0 2px;
+}

--- a/src/HotBox.Client/wwwroot/index.html
+++ b/src/HotBox.Client/wwwroot/index.html
@@ -28,6 +28,7 @@
         <a href="" class="reload">Reload</a>
         <a class="dismiss">X</a>
     </div>
+    <script src="js/search-interop.js"></script>
     <script src="js/notifications.js"></script>
     <script src="js/audio-interop.js"></script>
     <script src="js/webrtc-interop.js"></script>

--- a/src/HotBox.Client/wwwroot/js/search-interop.js
+++ b/src/HotBox.Client/wwwroot/js/search-interop.js
@@ -1,0 +1,30 @@
+// Search keyboard shortcut interop for Blazor WASM
+// Listens for Ctrl+K / Cmd+K globally and invokes a .NET method
+window.searchInterop = {
+    _dotNetRef: null,
+
+    register: function (dotNetRef) {
+        this._dotNetRef = dotNetRef;
+        document.addEventListener('keydown', this._handler);
+    },
+
+    unregister: function () {
+        document.removeEventListener('keydown', this._handler);
+        this._dotNetRef = null;
+    },
+
+    focusElement: function (element) {
+        if (element) {
+            element.focus();
+        }
+    },
+
+    _handler: function (e) {
+        if ((e.ctrlKey || e.metaKey) && e.key === 'k') {
+            e.preventDefault();
+            if (window.searchInterop._dotNetRef) {
+                window.searchInterop._dotNetRef.invokeMethodAsync('OnSearchShortcut');
+            }
+        }
+    }
+};

--- a/src/HotBox.Core/Interfaces/ISearchService.cs
+++ b/src/HotBox.Core/Interfaces/ISearchService.cs
@@ -1,0 +1,16 @@
+using HotBox.Core.Models;
+
+namespace HotBox.Core.Interfaces;
+
+public interface ISearchService
+{
+    Task<SearchResult> SearchMessagesAsync(SearchQuery query, CancellationToken ct = default);
+
+    Task InitializeIndexAsync(CancellationToken ct = default);
+
+    Task ReindexAsync(CancellationToken ct = default);
+
+    bool IsFullTextSearchAvailable { get; }
+
+    string ProviderName { get; }
+}

--- a/src/HotBox.Core/Models/SearchQuery.cs
+++ b/src/HotBox.Core/Models/SearchQuery.cs
@@ -1,0 +1,14 @@
+namespace HotBox.Core.Models;
+
+public class SearchQuery
+{
+    public string QueryText { get; set; } = string.Empty;
+
+    public Guid? ChannelId { get; set; }
+
+    public Guid? SenderId { get; set; }
+
+    public string? Cursor { get; set; }
+
+    public int Limit { get; set; } = 20;
+}

--- a/src/HotBox.Core/Models/SearchResult.cs
+++ b/src/HotBox.Core/Models/SearchResult.cs
@@ -1,0 +1,10 @@
+namespace HotBox.Core.Models;
+
+public class SearchResult
+{
+    public IReadOnlyList<SearchResultItem> Items { get; set; } = [];
+
+    public string? Cursor { get; set; }
+
+    public int TotalEstimate { get; set; }
+}

--- a/src/HotBox.Core/Models/SearchResultItem.cs
+++ b/src/HotBox.Core/Models/SearchResultItem.cs
@@ -1,0 +1,20 @@
+namespace HotBox.Core.Models;
+
+public class SearchResultItem
+{
+    public Guid MessageId { get; set; }
+
+    public string Snippet { get; set; } = string.Empty;
+
+    public Guid ChannelId { get; set; }
+
+    public string ChannelName { get; set; } = string.Empty;
+
+    public Guid AuthorId { get; set; }
+
+    public string AuthorDisplayName { get; set; } = string.Empty;
+
+    public DateTime CreatedAtUtc { get; set; }
+
+    public double RelevanceScore { get; set; }
+}

--- a/src/HotBox.Core/Options/SearchOptions.cs
+++ b/src/HotBox.Core/Options/SearchOptions.cs
@@ -1,0 +1,14 @@
+namespace HotBox.Core.Options;
+
+public class SearchOptions
+{
+    public const string SectionName = "Search";
+
+    public int MaxResults { get; set; } = 50;
+
+    public int DefaultLimit { get; set; } = 20;
+
+    public int MinQueryLength { get; set; } = 2;
+
+    public int SnippetLength { get; set; } = 150;
+}

--- a/src/HotBox.Infrastructure/Services/Search/FallbackSearchService.cs
+++ b/src/HotBox.Infrastructure/Services/Search/FallbackSearchService.cs
@@ -1,0 +1,171 @@
+using System.Net;
+using HotBox.Core.Interfaces;
+using HotBox.Core.Models;
+using HotBox.Core.Options;
+using HotBox.Infrastructure.Data;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+
+namespace HotBox.Infrastructure.Services.Search;
+
+public class FallbackSearchService : ISearchService
+{
+    private readonly HotBoxDbContext _context;
+    private readonly ILogger<FallbackSearchService> _logger;
+    private readonly SearchOptions _options;
+
+    public FallbackSearchService(
+        HotBoxDbContext context,
+        ILogger<FallbackSearchService> logger,
+        IOptions<SearchOptions> options)
+    {
+        _context = context;
+        _logger = logger;
+        _options = options.Value;
+    }
+
+    public bool IsFullTextSearchAvailable => false;
+
+    public string ProviderName => "Fallback (SQL LIKE)";
+
+    public Task InitializeIndexAsync(CancellationToken ct = default)
+    {
+        _logger.LogWarning(
+            "Full-text search is not available. Using fallback SQL LIKE search which may be slow on large datasets");
+        return Task.CompletedTask;
+    }
+
+    public Task ReindexAsync(CancellationToken ct = default)
+    {
+        _logger.LogWarning("Reindex requested but full-text search is not available; no index to rebuild");
+        return Task.CompletedTask;
+    }
+
+    public async Task<SearchResult> SearchMessagesAsync(SearchQuery query, CancellationToken ct = default)
+    {
+        try
+        {
+            var offset = 0;
+            if (!string.IsNullOrWhiteSpace(query.Cursor) && int.TryParse(query.Cursor, out var parsedOffset))
+            {
+                offset = parsedOffset;
+            }
+
+            var limit = Math.Min(query.Limit, _options.MaxResults);
+            // Escape LIKE wildcards to prevent pattern injection
+            var escapedQuery = query.QueryText
+                .Replace("\\", "\\\\")
+                .Replace("%", "\\%")
+                .Replace("_", "\\_");
+            var likePattern = $"%{escapedQuery}%";
+
+            var messagesQuery = _context.Messages
+                .Include(m => m.Channel)
+                .Include(m => m.Author)
+                .Where(m => EF.Functions.Like(m.Content, likePattern));
+
+            if (query.ChannelId.HasValue)
+            {
+                messagesQuery = messagesQuery.Where(m => m.ChannelId == query.ChannelId.Value);
+            }
+
+            if (query.SenderId.HasValue)
+            {
+                messagesQuery = messagesQuery.Where(m => m.AuthorId == query.SenderId.Value);
+            }
+
+            var totalEstimate = await messagesQuery.CountAsync(ct);
+
+            var messages = await messagesQuery
+                .OrderByDescending(m => m.CreatedAtUtc)
+                .Skip(offset)
+                .Take(limit + 1)
+                .ToListAsync(ct);
+
+            var hasMore = messages.Count > limit;
+            var snippetLength = _options.SnippetLength;
+
+            var resultItems = messages
+                .Take(limit)
+                .Select(m => new SearchResultItem
+                {
+                    MessageId = m.Id,
+                    Snippet = GenerateSnippet(m.Content, query.QueryText, snippetLength),
+                    ChannelId = m.ChannelId,
+                    ChannelName = m.Channel?.Name ?? "Unknown",
+                    AuthorId = m.AuthorId,
+                    AuthorDisplayName = m.Author?.DisplayName ?? "Unknown",
+                    CreatedAtUtc = m.CreatedAtUtc,
+                    RelevanceScore = 0.0,
+                })
+                .ToList();
+
+            return new SearchResult
+            {
+                Items = resultItems,
+                Cursor = hasMore ? (offset + limit).ToString() : null,
+                TotalEstimate = totalEstimate,
+            };
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Fallback search failed for query {Query}", query.QueryText);
+            return new SearchResult { Items = [], Cursor = null, TotalEstimate = 0 };
+        }
+    }
+
+    private static string GenerateSnippet(string content, string queryText, int snippetLength)
+    {
+        if (string.IsNullOrWhiteSpace(content))
+            return string.Empty;
+
+        var index = content.IndexOf(queryText, StringComparison.OrdinalIgnoreCase);
+        if (index < 0)
+        {
+            return content.Length <= snippetLength
+                ? content
+                : content[..snippetLength] + "...";
+        }
+
+        var halfSnippet = snippetLength / 2;
+        var start = Math.Max(0, index - halfSnippet);
+        var end = Math.Min(content.Length, start + snippetLength);
+        start = Math.Max(0, end - snippetLength);
+
+        var snippet = content[start..end];
+        var prefix = start > 0 ? "..." : "";
+        var suffix = end < content.Length ? "..." : "";
+
+        // Highlight matched terms with <mark> tags
+        var highlighted = HighlightTerms(snippet, queryText);
+
+        return prefix + highlighted + suffix;
+    }
+
+    private static string HighlightTerms(string text, string queryText)
+    {
+        // HTML-encode to prevent XSS before adding <mark> tags
+        var encoded = WebUtility.HtmlEncode(text);
+        var words = queryText.Split(' ', StringSplitOptions.RemoveEmptyEntries);
+        var result = encoded;
+
+        foreach (var word in words)
+        {
+            var encodedWord = WebUtility.HtmlEncode(word);
+            var idx = 0;
+            while (idx < result.Length)
+            {
+                var pos = result.IndexOf(encodedWord, idx, StringComparison.OrdinalIgnoreCase);
+                if (pos < 0) break;
+
+                var matched = result.Substring(pos, encodedWord.Length);
+                var replacement = $"<mark>{matched}</mark>";
+                result = result[..pos] + replacement + result[(pos + encodedWord.Length)..];
+                idx = pos + replacement.Length;
+            }
+        }
+
+        return result;
+    }
+}

--- a/src/HotBox.Infrastructure/Services/Search/MySqlSearchService.cs
+++ b/src/HotBox.Infrastructure/Services/Search/MySqlSearchService.cs
@@ -1,0 +1,286 @@
+using System.Net;
+using HotBox.Core.Interfaces;
+using HotBox.Core.Models;
+using HotBox.Core.Options;
+using HotBox.Infrastructure.Data;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+
+namespace HotBox.Infrastructure.Services.Search;
+
+public class MySqlSearchService : ISearchService
+{
+    private readonly HotBoxDbContext _context;
+    private readonly ILogger<MySqlSearchService> _logger;
+    private readonly SearchOptions _options;
+
+    public MySqlSearchService(
+        HotBoxDbContext context,
+        ILogger<MySqlSearchService> logger,
+        IOptions<SearchOptions> options)
+    {
+        _context = context;
+        _logger = logger;
+        _options = options.Value;
+    }
+
+    public bool IsFullTextSearchAvailable => true;
+
+    public string ProviderName => "MySQL (FULLTEXT)";
+
+    public async Task InitializeIndexAsync(CancellationToken ct = default)
+    {
+        try
+        {
+            _logger.LogInformation("Initializing MySQL FULLTEXT index on Messages.Content");
+
+            // MySQL doesn't support CREATE INDEX IF NOT EXISTS directly,
+            // so check if it exists first via information_schema
+            var indexExists = await _context.Database
+                .SqlQueryRaw<int>(
+                    """
+                    SELECT COUNT(*) AS `Value`
+                    FROM information_schema.STATISTICS
+                    WHERE TABLE_SCHEMA = DATABASE()
+                      AND TABLE_NAME = 'Messages'
+                      AND INDEX_NAME = 'IX_Messages_Content_FTS'
+                    """)
+                .FirstOrDefaultAsync(ct);
+
+            if (indexExists == 0)
+            {
+                await _context.Database.ExecuteSqlRawAsync(
+                    "CREATE FULLTEXT INDEX `IX_Messages_Content_FTS` ON `Messages` (`Content`)",
+                    ct);
+            }
+
+            _logger.LogInformation("MySQL FULLTEXT index initialized successfully");
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Failed to initialize MySQL FULLTEXT index");
+            throw;
+        }
+    }
+
+    public async Task ReindexAsync(CancellationToken ct = default)
+    {
+        try
+        {
+            _logger.LogInformation("Rebuilding MySQL FULLTEXT index on Messages.Content");
+
+            // MySQL rebuilds fulltext indexes via OPTIMIZE TABLE
+            await _context.Database.ExecuteSqlRawAsync(
+                "OPTIMIZE TABLE `Messages`",
+                ct);
+
+            _logger.LogInformation("MySQL FULLTEXT index rebuilt successfully");
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Failed to rebuild MySQL FULLTEXT index");
+            throw;
+        }
+    }
+
+    public async Task<SearchResult> SearchMessagesAsync(SearchQuery query, CancellationToken ct = default)
+    {
+        try
+        {
+            var offset = 0;
+            if (!string.IsNullOrWhiteSpace(query.Cursor) && int.TryParse(query.Cursor, out var parsedOffset))
+            {
+                offset = parsedOffset;
+            }
+
+            var limit = Math.Min(query.Limit, _options.MaxResults);
+
+            // Build filter clauses and parameters dynamically
+            var filters = new List<string>();
+            var parameters = new List<object> { query.QueryText }; // {0} = query text
+            var paramIndex = 1;
+
+            if (query.ChannelId.HasValue)
+            {
+                filters.Add($"AND m.`ChannelId` = {{{paramIndex}}}");
+                parameters.Add(query.ChannelId.Value);
+                paramIndex++;
+            }
+
+            if (query.SenderId.HasValue)
+            {
+                filters.Add($"AND m.`AuthorId` = {{{paramIndex}}}");
+                parameters.Add(query.SenderId.Value);
+                paramIndex++;
+            }
+
+            var filterClause = filters.Count > 0 ? string.Join(" ", filters) : "";
+
+            var offsetParamIndex = paramIndex;
+            parameters.Add(offset);
+            paramIndex++;
+            var limitParamIndex = paramIndex;
+            parameters.Add(limit + 1);
+
+            var sql = @$"SELECT
+    m.`Id` AS `MessageId`,
+    m.`Content` AS `Snippet`,
+    m.`ChannelId`,
+    c.`Name` AS `ChannelName`,
+    m.`AuthorId`,
+    u.`DisplayName` AS `AuthorDisplayName`,
+    m.`CreatedAtUtc`,
+    MATCH(m.`Content`) AGAINST({{0}} IN NATURAL LANGUAGE MODE) AS `RelevanceScore`
+FROM `Messages` m
+INNER JOIN `Channels` c ON c.`Id` = m.`ChannelId`
+INNER JOIN `AspNetUsers` u ON u.`Id` = m.`AuthorId`
+WHERE MATCH(m.`Content`) AGAINST({{0}} IN NATURAL LANGUAGE MODE)
+    {filterClause}
+ORDER BY `RelevanceScore` DESC, m.`CreatedAtUtc` DESC
+LIMIT {{{limitParamIndex}}} OFFSET {{{offsetParamIndex}}}";
+
+            var items = await _context.Database
+                .SqlQueryRaw<SearchResultItemRaw>(sql, parameters.ToArray())
+                .ToListAsync(ct);
+
+            var hasMore = items.Count > limit;
+            var snippetLength = _options.SnippetLength;
+
+            var resultItems = items
+                .Take(limit)
+                .Select(r => new SearchResultItem
+                {
+                    MessageId = r.MessageId,
+                    Snippet = GenerateSnippet(r.Snippet, query.QueryText, snippetLength),
+                    ChannelId = r.ChannelId,
+                    ChannelName = r.ChannelName,
+                    AuthorId = r.AuthorId,
+                    AuthorDisplayName = r.AuthorDisplayName,
+                    CreatedAtUtc = r.CreatedAtUtc,
+                    RelevanceScore = r.RelevanceScore,
+                })
+                .ToList();
+
+            // Count total estimate
+            var countParams = new List<object> { query.QueryText };
+            var countFilters = new List<string>();
+            var countParamIdx = 1;
+
+            if (query.ChannelId.HasValue)
+            {
+                countFilters.Add($"AND m.`ChannelId` = {{{countParamIdx}}}");
+                countParams.Add(query.ChannelId.Value);
+                countParamIdx++;
+            }
+
+            if (query.SenderId.HasValue)
+            {
+                countFilters.Add($"AND m.`AuthorId` = {{{countParamIdx}}}");
+                countParams.Add(query.SenderId.Value);
+                countParamIdx++;
+            }
+
+            var countFilterClause = countFilters.Count > 0 ? string.Join(" ", countFilters) : "";
+
+            var countSql = @$"SELECT COUNT(*) AS `Value`
+FROM `Messages` m
+WHERE MATCH(m.`Content`) AGAINST({{0}} IN NATURAL LANGUAGE MODE)
+    {countFilterClause}";
+
+            var totalEstimate = await _context.Database
+                .SqlQueryRaw<int>(countSql, countParams.ToArray())
+                .FirstOrDefaultAsync(ct);
+
+            return new SearchResult
+            {
+                Items = resultItems,
+                Cursor = hasMore ? (offset + limit).ToString() : null,
+                TotalEstimate = totalEstimate,
+            };
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "MySQL full-text search failed for query {Query}", query.QueryText);
+            return new SearchResult { Items = [], Cursor = null, TotalEstimate = 0 };
+        }
+    }
+
+    private static string GenerateSnippet(string content, string queryText, int snippetLength)
+    {
+        if (string.IsNullOrWhiteSpace(content))
+            return string.Empty;
+
+        var index = content.IndexOf(queryText, StringComparison.OrdinalIgnoreCase);
+        if (index < 0)
+        {
+            // Try to match individual words from the query
+            var words = queryText.Split(' ', StringSplitOptions.RemoveEmptyEntries);
+            foreach (var word in words)
+            {
+                index = content.IndexOf(word, StringComparison.OrdinalIgnoreCase);
+                if (index >= 0) break;
+            }
+        }
+
+        if (index < 0)
+        {
+            // No match found, return start of content
+            return content.Length <= snippetLength
+                ? content
+                : content[..snippetLength] + "...";
+        }
+
+        var halfSnippet = snippetLength / 2;
+        var start = Math.Max(0, index - halfSnippet);
+        var end = Math.Min(content.Length, start + snippetLength);
+        start = Math.Max(0, end - snippetLength);
+
+        var snippet = content[start..end];
+        var prefix = start > 0 ? "..." : "";
+        var suffix = end < content.Length ? "..." : "";
+
+        // Highlight matched terms with <mark> tags
+        var highlighted = HighlightTerms(snippet, queryText);
+
+        return prefix + highlighted + suffix;
+    }
+
+    private static string HighlightTerms(string text, string queryText)
+    {
+        // HTML-encode to prevent XSS before adding <mark> tags
+        var encoded = WebUtility.HtmlEncode(text);
+        var words = queryText.Split(' ', StringSplitOptions.RemoveEmptyEntries);
+        var result = encoded;
+
+        foreach (var word in words)
+        {
+            var encodedWord = WebUtility.HtmlEncode(word);
+            var idx = 0;
+            while (idx < result.Length)
+            {
+                var pos = result.IndexOf(encodedWord, idx, StringComparison.OrdinalIgnoreCase);
+                if (pos < 0) break;
+
+                var matched = result.Substring(pos, encodedWord.Length);
+                var replacement = $"<mark>{matched}</mark>";
+                result = result[..pos] + replacement + result[(pos + encodedWord.Length)..];
+                idx = pos + replacement.Length;
+            }
+        }
+
+        return result;
+    }
+
+    private class SearchResultItemRaw
+    {
+        public Guid MessageId { get; set; }
+        public string Snippet { get; set; } = string.Empty;
+        public Guid ChannelId { get; set; }
+        public string ChannelName { get; set; } = string.Empty;
+        public Guid AuthorId { get; set; }
+        public string AuthorDisplayName { get; set; } = string.Empty;
+        public DateTime CreatedAtUtc { get; set; }
+        public double RelevanceScore { get; set; }
+    }
+}

--- a/src/HotBox.Infrastructure/Services/Search/PostgresSearchService.cs
+++ b/src/HotBox.Infrastructure/Services/Search/PostgresSearchService.cs
@@ -1,0 +1,222 @@
+using System.Net;
+using HotBox.Core.Interfaces;
+using HotBox.Core.Models;
+using HotBox.Core.Options;
+using HotBox.Infrastructure.Data;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+
+namespace HotBox.Infrastructure.Services.Search;
+
+public class PostgresSearchService : ISearchService
+{
+    private readonly HotBoxDbContext _context;
+    private readonly ILogger<PostgresSearchService> _logger;
+    private readonly SearchOptions _options;
+
+    public PostgresSearchService(
+        HotBoxDbContext context,
+        ILogger<PostgresSearchService> logger,
+        IOptions<SearchOptions> options)
+    {
+        _context = context;
+        _logger = logger;
+        _options = options.Value;
+    }
+
+    public bool IsFullTextSearchAvailable => true;
+
+    public string ProviderName => "PostgreSQL (tsvector/GIN)";
+
+    public async Task InitializeIndexAsync(CancellationToken ct = default)
+    {
+        try
+        {
+            _logger.LogInformation("Initializing PostgreSQL GIN index on Messages.Content");
+
+            await _context.Database.ExecuteSqlRawAsync(
+                """
+                CREATE INDEX IF NOT EXISTS "IX_Messages_Content_FTS"
+                ON "Messages" USING GIN (to_tsvector('english', "Content"))
+                """,
+                ct);
+
+            _logger.LogInformation("PostgreSQL GIN index initialized successfully");
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Failed to initialize PostgreSQL GIN index");
+            throw;
+        }
+    }
+
+    public async Task ReindexAsync(CancellationToken ct = default)
+    {
+        try
+        {
+            _logger.LogInformation("Rebuilding PostgreSQL GIN index on Messages.Content");
+
+            await _context.Database.ExecuteSqlRawAsync(
+                """REINDEX INDEX "IX_Messages_Content_FTS" """,
+                ct);
+
+            _logger.LogInformation("PostgreSQL GIN index rebuilt successfully");
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Failed to rebuild PostgreSQL GIN index");
+            throw;
+        }
+    }
+
+    public async Task<SearchResult> SearchMessagesAsync(SearchQuery query, CancellationToken ct = default)
+    {
+        try
+        {
+            var offset = 0;
+            if (!string.IsNullOrWhiteSpace(query.Cursor) && int.TryParse(query.Cursor, out var parsedOffset))
+            {
+                offset = parsedOffset;
+            }
+
+            var limit = Math.Min(query.Limit, _options.MaxResults);
+
+            // Build filter clauses and parameters dynamically
+            var filters = new List<string>();
+            var parameters = new List<object> { query.QueryText }; // {0} = query text
+            var paramIndex = 1;
+
+            if (query.ChannelId.HasValue)
+            {
+                filters.Add($@"AND m.""ChannelId"" = {{{paramIndex}}}");
+                parameters.Add(query.ChannelId.Value);
+                paramIndex++;
+            }
+
+            if (query.SenderId.HasValue)
+            {
+                filters.Add($@"AND m.""AuthorId"" = {{{paramIndex}}}");
+                parameters.Add(query.SenderId.Value);
+                paramIndex++;
+            }
+
+            var filterClause = filters.Count > 0 ? string.Join(" ", filters) : "";
+
+            // Offset and limit parameters
+            var offsetParamIndex = paramIndex;
+            parameters.Add(offset);
+            paramIndex++;
+            var limitParamIndex = paramIndex;
+            parameters.Add(limit + 1); // Fetch one extra to detect next page
+
+            var sql = @$"SELECT
+    m.""Id"" AS ""MessageId"",
+    ts_headline('english', m.""Content"", plainto_tsquery('english', {{0}}),
+        'StartSel=\x01, StopSel=\x02, MaxFragments=1, MaxWords=50, MinWords=20') AS ""Snippet"",
+    m.""ChannelId"",
+    c.""Name"" AS ""ChannelName"",
+    m.""AuthorId"",
+    u.""DisplayName"" AS ""AuthorDisplayName"",
+    m.""CreatedAtUtc"",
+    ts_rank(to_tsvector('english', m.""Content""), plainto_tsquery('english', {{0}})) AS ""RelevanceScore""
+FROM ""Messages"" m
+INNER JOIN ""Channels"" c ON c.""Id"" = m.""ChannelId""
+INNER JOIN ""AspNetUsers"" u ON u.""Id"" = m.""AuthorId""
+WHERE to_tsvector('english', m.""Content"") @@ plainto_tsquery('english', {{0}})
+    {filterClause}
+ORDER BY ""RelevanceScore"" DESC, m.""CreatedAtUtc"" DESC
+OFFSET {{{offsetParamIndex}}} ROWS FETCH NEXT {{{limitParamIndex}}} ROWS ONLY";
+
+            var items = await _context.Database
+                .SqlQueryRaw<SearchResultItemRaw>(sql, parameters.ToArray())
+                .ToListAsync(ct);
+
+            var hasMore = items.Count > limit;
+            var resultItems = items
+                .Take(limit)
+                .Select(r => new SearchResultItem
+                {
+                    MessageId = r.MessageId,
+                    Snippet = SanitizeSnippet(r.Snippet),
+                    ChannelId = r.ChannelId,
+                    ChannelName = r.ChannelName,
+                    AuthorId = r.AuthorId,
+                    AuthorDisplayName = r.AuthorDisplayName,
+                    CreatedAtUtc = r.CreatedAtUtc,
+                    RelevanceScore = r.RelevanceScore,
+                })
+                .ToList();
+
+            // Count total estimate
+            var countParams = new List<object> { query.QueryText };
+            var countFilters = new List<string>();
+            var countParamIdx = 1;
+
+            if (query.ChannelId.HasValue)
+            {
+                countFilters.Add($@"AND m.""ChannelId"" = {{{countParamIdx}}}");
+                countParams.Add(query.ChannelId.Value);
+                countParamIdx++;
+            }
+
+            if (query.SenderId.HasValue)
+            {
+                countFilters.Add($@"AND m.""AuthorId"" = {{{countParamIdx}}}");
+                countParams.Add(query.SenderId.Value);
+                countParamIdx++;
+            }
+
+            var countFilterClause = countFilters.Count > 0 ? string.Join(" ", countFilters) : "";
+
+            var countSql = @$"SELECT COUNT(*)::int AS ""Value""
+FROM ""Messages"" m
+WHERE to_tsvector('english', m.""Content"") @@ plainto_tsquery('english', {{0}})
+    {countFilterClause}";
+
+            var totalEstimate = await _context.Database
+                .SqlQueryRaw<int>(countSql, countParams.ToArray())
+                .FirstOrDefaultAsync(ct);
+
+            return new SearchResult
+            {
+                Items = resultItems,
+                Cursor = hasMore ? (offset + limit).ToString() : null,
+                TotalEstimate = totalEstimate,
+            };
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "PostgreSQL full-text search failed for query {Query}", query.QueryText);
+            return new SearchResult { Items = [], Cursor = null, TotalEstimate = 0 };
+        }
+    }
+
+    /// <summary>
+    /// HTML-encodes snippet content while preserving highlight markers.
+    /// ts_headline uses control chars \x01/\x02 as markers which pass through HtmlEncode unchanged.
+    /// </summary>
+    private static string SanitizeSnippet(string snippet)
+    {
+        if (string.IsNullOrEmpty(snippet))
+            return string.Empty;
+
+        var sanitized = WebUtility.HtmlEncode(snippet);
+        return sanitized
+            .Replace("\x01", "<mark>")
+            .Replace("\x02", "</mark>");
+    }
+
+    // Internal DTO for raw SQL mapping
+    private class SearchResultItemRaw
+    {
+        public Guid MessageId { get; set; }
+        public string Snippet { get; set; } = string.Empty;
+        public Guid ChannelId { get; set; }
+        public string ChannelName { get; set; } = string.Empty;
+        public Guid AuthorId { get; set; }
+        public string AuthorDisplayName { get; set; } = string.Empty;
+        public DateTime CreatedAtUtc { get; set; }
+        public double RelevanceScore { get; set; }
+    }
+}

--- a/src/HotBox.Infrastructure/Services/Search/SqliteSearchService.cs
+++ b/src/HotBox.Infrastructure/Services/Search/SqliteSearchService.cs
@@ -1,0 +1,249 @@
+using System.Net;
+using HotBox.Core.Interfaces;
+using HotBox.Core.Models;
+using HotBox.Core.Options;
+using HotBox.Infrastructure.Data;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+
+namespace HotBox.Infrastructure.Services.Search;
+
+public class SqliteSearchService : ISearchService
+{
+    private readonly HotBoxDbContext _context;
+    private readonly ILogger<SqliteSearchService> _logger;
+    private readonly SearchOptions _options;
+
+    public SqliteSearchService(
+        HotBoxDbContext context,
+        ILogger<SqliteSearchService> logger,
+        IOptions<SearchOptions> options)
+    {
+        _context = context;
+        _logger = logger;
+        _options = options.Value;
+    }
+
+    public bool IsFullTextSearchAvailable => true;
+
+    public string ProviderName => "SQLite (FTS5)";
+
+    public async Task InitializeIndexAsync(CancellationToken ct = default)
+    {
+        try
+        {
+            _logger.LogInformation("Initializing SQLite FTS5 virtual table and triggers");
+
+            // Create the FTS5 virtual table if it doesn't exist
+            await _context.Database.ExecuteSqlRawAsync(
+                """
+                CREATE VIRTUAL TABLE IF NOT EXISTS "MessagesFts"
+                USING fts5(content, content="Messages", content_rowid="rowid")
+                """,
+                ct);
+
+            // Create triggers to keep the FTS table in sync
+            // Insert trigger
+            await _context.Database.ExecuteSqlRawAsync(
+                """
+                CREATE TRIGGER IF NOT EXISTS "Messages_ai" AFTER INSERT ON "Messages" BEGIN
+                    INSERT INTO "MessagesFts"(rowid, content) VALUES (new.rowid, new."Content");
+                END
+                """,
+                ct);
+
+            // Delete trigger
+            await _context.Database.ExecuteSqlRawAsync(
+                """
+                CREATE TRIGGER IF NOT EXISTS "Messages_ad" AFTER DELETE ON "Messages" BEGIN
+                    INSERT INTO "MessagesFts"("MessagesFts", rowid, content) VALUES('delete', old.rowid, old."Content");
+                END
+                """,
+                ct);
+
+            // Update trigger
+            await _context.Database.ExecuteSqlRawAsync(
+                """
+                CREATE TRIGGER IF NOT EXISTS "Messages_au" AFTER UPDATE ON "Messages" BEGIN
+                    INSERT INTO "MessagesFts"("MessagesFts", rowid, content) VALUES('delete', old.rowid, old."Content");
+                    INSERT INTO "MessagesFts"(rowid, content) VALUES (new.rowid, new."Content");
+                END
+                """,
+                ct);
+
+            _logger.LogInformation("SQLite FTS5 virtual table and triggers initialized successfully");
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Failed to initialize SQLite FTS5 virtual table");
+            throw;
+        }
+    }
+
+    public async Task ReindexAsync(CancellationToken ct = default)
+    {
+        try
+        {
+            _logger.LogInformation("Rebuilding SQLite FTS5 index");
+
+            // Rebuild the FTS5 index by repopulating from the content table
+            await _context.Database.ExecuteSqlRawAsync(
+                """INSERT INTO "MessagesFts"("MessagesFts") VALUES('rebuild')""",
+                ct);
+
+            _logger.LogInformation("SQLite FTS5 index rebuilt successfully");
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Failed to rebuild SQLite FTS5 index");
+            throw;
+        }
+    }
+
+    public async Task<SearchResult> SearchMessagesAsync(SearchQuery query, CancellationToken ct = default)
+    {
+        try
+        {
+            var offset = 0;
+            if (!string.IsNullOrWhiteSpace(query.Cursor) && int.TryParse(query.Cursor, out var parsedOffset))
+            {
+                offset = parsedOffset;
+            }
+
+            var limit = Math.Min(query.Limit, _options.MaxResults);
+
+            // Build filter clauses and parameters dynamically
+            var filters = new List<string>();
+            var parameters = new List<object> { query.QueryText }; // {0} = query text
+            var paramIndex = 1;
+
+            if (query.ChannelId.HasValue)
+            {
+                filters.Add($@"AND m.""ChannelId"" = {{{paramIndex}}}");
+                parameters.Add(query.ChannelId.Value);
+                paramIndex++;
+            }
+
+            if (query.SenderId.HasValue)
+            {
+                filters.Add($@"AND m.""AuthorId"" = {{{paramIndex}}}");
+                parameters.Add(query.SenderId.Value);
+                paramIndex++;
+            }
+
+            var filterClause = filters.Count > 0 ? string.Join(" ", filters) : "";
+
+            var offsetParamIndex = paramIndex;
+            parameters.Add(offset);
+            paramIndex++;
+            var limitParamIndex = paramIndex;
+            parameters.Add(limit + 1);
+
+            var sql = @$"SELECT
+    m.""Id"" AS ""MessageId"",
+    snippet(""MessagesFts"", 0, X'01', X'02', '...', 32) AS ""Snippet"",
+    m.""ChannelId"",
+    c.""Name"" AS ""ChannelName"",
+    m.""AuthorId"",
+    u.""DisplayName"" AS ""AuthorDisplayName"",
+    m.""CreatedAtUtc"",
+    CAST(-""MessagesFts"".rank AS REAL) AS ""RelevanceScore""
+FROM ""MessagesFts""
+INNER JOIN ""Messages"" m ON m.rowid = ""MessagesFts"".rowid
+INNER JOIN ""Channels"" c ON c.""Id"" = m.""ChannelId""
+INNER JOIN ""AspNetUsers"" u ON u.""Id"" = m.""AuthorId""
+WHERE ""MessagesFts"" MATCH {{0}}
+    {filterClause}
+ORDER BY ""MessagesFts"".rank
+LIMIT {{{limitParamIndex}}} OFFSET {{{offsetParamIndex}}}";
+
+            var items = await _context.Database
+                .SqlQueryRaw<SearchResultItemRaw>(sql, parameters.ToArray())
+                .ToListAsync(ct);
+
+            var hasMore = items.Count > limit;
+
+            var resultItems = items
+                .Take(limit)
+                .Select(r => new SearchResultItem
+                {
+                    MessageId = r.MessageId,
+                    Snippet = SanitizeSnippet(r.Snippet),
+                    ChannelId = r.ChannelId,
+                    ChannelName = r.ChannelName,
+                    AuthorId = r.AuthorId,
+                    AuthorDisplayName = r.AuthorDisplayName,
+                    CreatedAtUtc = r.CreatedAtUtc,
+                    RelevanceScore = r.RelevanceScore,
+                })
+                .ToList();
+
+            // Count total estimate
+            var countParams = new List<object> { query.QueryText };
+            var countFilters = new List<string>();
+            var countParamIdx = 1;
+
+            if (query.ChannelId.HasValue)
+            {
+                countFilters.Add($@"AND m.""ChannelId"" = {{{countParamIdx}}}");
+                countParams.Add(query.ChannelId.Value);
+                countParamIdx++;
+            }
+
+            if (query.SenderId.HasValue)
+            {
+                countFilters.Add($@"AND m.""AuthorId"" = {{{countParamIdx}}}");
+                countParams.Add(query.SenderId.Value);
+                countParamIdx++;
+            }
+
+            var countFilterClause = countFilters.Count > 0 ? string.Join(" ", countFilters) : "";
+
+            var countSql = @$"SELECT COUNT(*) AS ""Value""
+FROM ""MessagesFts""
+INNER JOIN ""Messages"" m ON m.rowid = ""MessagesFts"".rowid
+WHERE ""MessagesFts"" MATCH {{0}}
+    {countFilterClause}";
+
+            var totalEstimate = await _context.Database
+                .SqlQueryRaw<int>(countSql, countParams.ToArray())
+                .FirstOrDefaultAsync(ct);
+
+            return new SearchResult
+            {
+                Items = resultItems,
+                Cursor = hasMore ? (offset + limit).ToString() : null,
+                TotalEstimate = totalEstimate,
+            };
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "SQLite FTS5 search failed for query {Query}", query.QueryText);
+            return new SearchResult { Items = [], Cursor = null, TotalEstimate = 0 };
+        }
+    }
+
+    private static string SanitizeSnippet(string snippet)
+    {
+        if (string.IsNullOrEmpty(snippet))
+            return string.Empty;
+
+        var sanitized = WebUtility.HtmlEncode(snippet);
+        return sanitized
+            .Replace("\x01", "<mark>")
+            .Replace("\x02", "</mark>");
+    }
+
+    private class SearchResultItemRaw
+    {
+        public Guid MessageId { get; set; }
+        public string Snippet { get; set; } = string.Empty;
+        public Guid ChannelId { get; set; }
+        public string ChannelName { get; set; } = string.Empty;
+        public Guid AuthorId { get; set; }
+        public string AuthorDisplayName { get; set; } = string.Empty;
+        public DateTime CreatedAtUtc { get; set; }
+        public double RelevanceScore { get; set; }
+    }
+}


### PR DESCRIPTION
## Summary

- Implements full-text search across all database providers with native FTS optimization (PostgreSQL tsvector/GIN, MySQL FULLTEXT, SQLite FTS5) and graceful SQL LIKE fallback
- Adds REST API endpoints: `GET /api/search/messages`, `GET /api/search/status`, `POST /api/search/reindex` (admin-only)
- Adds Blazor SearchOverlay component with Ctrl+K/Cmd+K shortcut, 300ms debounced input, keyboard navigation, channel filtering, and jump-to-message navigation

### Backend (#45, #46, #47, #48, #49, #50)
- `ISearchService` interface and search models (`SearchQuery`, `SearchResult`, `SearchResultItem`) in Core
- `PostgresSearchService` — tsvector/GIN index, `plainto_tsquery`, `ts_rank`, `ts_headline` for snippets
- `MySqlSearchService` — FULLTEXT index, `MATCH...AGAINST` natural language mode
- `SqliteSearchService` — FTS5 virtual table with triggers for content sync, BM25 ranking, `snippet()` function
- `FallbackSearchService` — SQL LIKE with escaped wildcards, degraded mode logging
- `SearchController` with three endpoints and response DTOs
- `SearchOptions` configuration class with `IOptions<T>` pattern
- Conditional DI registration selects provider based on `Database:Provider` config
- Search index initialization on startup via `ISearchService.InitializeIndexAsync`

### Frontend (#51)
- `SearchOverlay.razor` — modal overlay with debounced input, keyboard navigation (arrows + Enter), channel filter dropdown
- `SearchState` — client-side state following existing `OnChange` event pattern
- `SearchResultItemModel` / `SearchResultModel` — client DTOs
- `ApiClient.SearchMessagesAsync` — API integration
- JS interop (`search-interop.js`) for global Ctrl+K/Cmd+K keyboard shortcut
- Dark-theme CSS matching existing design tokens

### Security
- All raw SQL queries use parameterized inputs via `SqlQueryRaw`
- XSS prevention: snippets use control-char markers in DB, HTML-encoded before converting to `<mark>` tags
- LIKE pattern injection prevented by escaping `%`, `_`, `\` wildcards in FallbackSearchService

Closes #5
Closes #45
Closes #46
Closes #47
Closes #48
Closes #49
Closes #50
Closes #51

## Test plan

- [ ] Build passes with zero errors/warnings (`dotnet build`)
- [ ] Search overlay opens via Ctrl+K keyboard shortcut
- [ ] Search overlay opens via search icon button in topbar
- [ ] Search returns results after typing 2+ characters with 300ms debounce
- [ ] Results show highlighted snippets, author, channel, timestamp
- [ ] Clicking a result navigates to the correct channel
- [ ] Escape closes the overlay
- [ ] Arrow keys navigate results, Enter selects
- [ ] Channel filter dropdown filters results
- [ ] `GET /api/search/status` returns provider info
- [ ] `POST /api/search/reindex` works for admin users only
- [ ] Test with SQLite (default dev) to verify FTS5 virtual table and triggers

🤖 Generated with [Claude Code](https://claude.com/claude-code)