### PR TITLE
fix: surface server error details in MCP tools and fix JWT claim mapping (#160)

### DIFF
--- a/src/HotBox.Application/DependencyInjection/ApplicationServiceExtensions.cs
+++ b/src/HotBox.Application/DependencyInjection/ApplicationServiceExtensions.cs
@@ -58,6 +58,7 @@ public static class ApplicationServiceExtensions
             ApiKeyAuthenticationHandler.SchemeName, null)
         .AddJwtBearer(options =>
         {
+            options.MapInboundClaims = true;
             options.TokenValidationParameters = new TokenValidationParameters
             {
                 ValidateIssuer = true,

--- a/src/HotBox.Mcp/Clients/HotBoxApiClient.cs
+++ b/src/HotBox.Mcp/Clients/HotBoxApiClient.cs
@@ -23,7 +23,14 @@ public class HotBoxApiClient
     {
         var payload = new { email, displayName };
         var response = await _httpClient.PostAsJsonAsync("/api/admin/agents", payload, cancellationToken);
-        response.EnsureSuccessStatusCode();
+        if (!response.IsSuccessStatusCode)
+        {
+            var errorBody = await response.Content.ReadAsStringAsync(cancellationToken);
+            throw new HttpRequestException(
+                $"Response status code does not indicate success: {(int)response.StatusCode} ({response.ReasonPhrase}). Body: {errorBody}",
+                null,
+                response.StatusCode);
+        }
         return await response.Content.ReadFromJsonAsync<JsonElement>(cancellationToken);
     }
 
@@ -33,7 +40,14 @@ public class HotBoxApiClient
     public async Task<JsonElement> ListAgentAccountsAsync(CancellationToken cancellationToken = default)
     {
         var response = await _httpClient.GetAsync("/api/admin/agents", cancellationToken);
-        response.EnsureSuccessStatusCode();
+        if (!response.IsSuccessStatusCode)
+        {
+            var errorBody = await response.Content.ReadAsStringAsync(cancellationToken);
+            throw new HttpRequestException(
+                $"Response status code does not indicate success: {(int)response.StatusCode} ({response.ReasonPhrase}). Body: {errorBody}",
+                null,
+                response.StatusCode);
+        }
         return await response.Content.ReadFromJsonAsync<JsonElement>(cancellationToken);
     }
 
@@ -47,7 +61,14 @@ public class HotBoxApiClient
         request.Content = JsonContent.Create(new { content });
 
         var response = await _httpClient.SendAsync(request, cancellationToken);
-        response.EnsureSuccessStatusCode();
+        if (!response.IsSuccessStatusCode)
+        {
+            var errorBody = await response.Content.ReadAsStringAsync(cancellationToken);
+            throw new HttpRequestException(
+                $"Response status code does not indicate success: {(int)response.StatusCode} ({response.ReasonPhrase}). Body: {errorBody}",
+                null,
+                response.StatusCode);
+        }
         return await response.Content.ReadFromJsonAsync<JsonElement>(cancellationToken);
     }
 
@@ -61,7 +82,14 @@ public class HotBoxApiClient
         request.Content = JsonContent.Create(new { content });
 
         var response = await _httpClient.SendAsync(request, cancellationToken);
-        response.EnsureSuccessStatusCode();
+        if (!response.IsSuccessStatusCode)
+        {
+            var errorBody = await response.Content.ReadAsStringAsync(cancellationToken);
+            throw new HttpRequestException(
+                $"Response status code does not indicate success: {(int)response.StatusCode} ({response.ReasonPhrase}). Body: {errorBody}",
+                null,
+                response.StatusCode);
+        }
         return await response.Content.ReadFromJsonAsync<JsonElement>(cancellationToken);
     }
 
@@ -74,7 +102,14 @@ public class HotBoxApiClient
         request.Headers.Authorization = new AuthenticationHeaderValue("Bearer", bearerToken);
 
         var response = await _httpClient.SendAsync(request, cancellationToken);
-        response.EnsureSuccessStatusCode();
+        if (!response.IsSuccessStatusCode)
+        {
+            var errorBody = await response.Content.ReadAsStringAsync(cancellationToken);
+            throw new HttpRequestException(
+                $"Response status code does not indicate success: {(int)response.StatusCode} ({response.ReasonPhrase}). Body: {errorBody}",
+                null,
+                response.StatusCode);
+        }
         return await response.Content.ReadFromJsonAsync<JsonElement>(cancellationToken);
     }
 
@@ -87,7 +122,14 @@ public class HotBoxApiClient
         request.Headers.Authorization = new AuthenticationHeaderValue("Bearer", bearerToken);
 
         var response = await _httpClient.SendAsync(request, cancellationToken);
-        response.EnsureSuccessStatusCode();
+        if (!response.IsSuccessStatusCode)
+        {
+            var errorBody = await response.Content.ReadAsStringAsync(cancellationToken);
+            throw new HttpRequestException(
+                $"Response status code does not indicate success: {(int)response.StatusCode} ({response.ReasonPhrase}). Body: {errorBody}",
+                null,
+                response.StatusCode);
+        }
         return await response.Content.ReadFromJsonAsync<JsonElement>(cancellationToken);
     }
 }

--- a/src/HotBox.Mcp/Tools/CreateAgentAccountTool.cs
+++ b/src/HotBox.Mcp/Tools/CreateAgentAccountTool.cs
@@ -39,7 +39,7 @@ public static class CreateAgentAccountTool
         catch (HttpRequestException ex)
         {
             var statusCode = ex.StatusCode != null ? $"HTTP {(int)ex.StatusCode}" : "HTTP error";
-            return $"Error: {statusCode} - Request failed";
+            return $"Error: {statusCode} - {ex.Message}";
         }
     }
 }

--- a/src/HotBox.Mcp/Tools/ListAgentAccountsTool.cs
+++ b/src/HotBox.Mcp/Tools/ListAgentAccountsTool.cs
@@ -26,7 +26,7 @@ public static class ListAgentAccountsTool
         catch (HttpRequestException ex)
         {
             var statusCode = ex.StatusCode != null ? $"HTTP {(int)ex.StatusCode}" : "HTTP error";
-            return $"Error: {statusCode} - Request failed";
+            return $"Error: {statusCode} - {ex.Message}";
         }
     }
 }

--- a/src/HotBox.Mcp/Tools/ReadDirectMessagesTool.cs
+++ b/src/HotBox.Mcp/Tools/ReadDirectMessagesTool.cs
@@ -35,7 +35,7 @@ public static class ReadDirectMessagesTool
         catch (HttpRequestException ex)
         {
             var statusCode = ex.StatusCode != null ? $"HTTP {(int)ex.StatusCode}" : "HTTP error";
-            return $"Error: {statusCode} - Request failed";
+            return $"Error: {statusCode} - {ex.Message}";
         }
     }
 }

--- a/src/HotBox.Mcp/Tools/ReadMessagesTool.cs
+++ b/src/HotBox.Mcp/Tools/ReadMessagesTool.cs
@@ -35,7 +35,7 @@ public static class ReadMessagesTool
         catch (HttpRequestException ex)
         {
             var statusCode = ex.StatusCode != null ? $"HTTP {(int)ex.StatusCode}" : "HTTP error";
-            return $"Error: {statusCode} - Request failed";
+            return $"Error: {statusCode} - {ex.Message}";
         }
     }
 }

--- a/src/HotBox.Mcp/Tools/SendDirectMessageTool.cs
+++ b/src/HotBox.Mcp/Tools/SendDirectMessageTool.cs
@@ -40,7 +40,7 @@ public static class SendDirectMessageTool
         catch (HttpRequestException ex)
         {
             var statusCode = ex.StatusCode != null ? $"HTTP {(int)ex.StatusCode}" : "HTTP error";
-            return $"Error: {statusCode} - Request failed";
+            return $"Error: {statusCode} - {ex.Message}";
         }
     }
 }

--- a/src/HotBox.Mcp/Tools/SendMessageTool.cs
+++ b/src/HotBox.Mcp/Tools/SendMessageTool.cs
@@ -40,7 +40,7 @@ public static class SendMessageTool
         catch (HttpRequestException ex)
         {
             var statusCode = ex.StatusCode != null ? $"HTTP {(int)ex.StatusCode}" : "HTTP error";
-            return $"Error: {statusCode} - Request failed";
+            return $"Error: {statusCode} - {ex.Message}";
         }
     }
 }


### PR DESCRIPTION
## Summary

This PR fixes issue #160 by improving error reporting in the MCP server and fixing JWT claim mapping so authenticated requests work correctly.

### Fix 1: Better error reporting in HotBoxApiClient
Replaced `EnsureSuccessStatusCode()` with manual status checks in all 6 methods of `HotBoxApiClient.cs`. On failure, the response body is now read and included in the `HttpRequestException` message, so callers can see the server's actual error (e.g., `"Unable to determine user identity."`).

### Fix 2: Surface error details in MCP tools
Updated all 6 MCP tool error handlers to use `ex.Message` instead of the generic `"Request failed"` string. Now errors include the full server response body.

### Fix 3: JWT claim mapping
Added `options.MapInboundClaims = true` to the JWT bearer configuration in `ApplicationServiceExtensions.cs`. This ensures the JWT `sub` claim maps to `ClaimTypes.NameIdentifier`, which `MessagesController.SendMessage` requires to identify the user.

## Files Changed
- src/HotBox.Mcp/Clients/HotBoxApiClient.cs
- src/HotBox.Mcp/Tools/SendMessageTool.cs
- src/HotBox.Mcp/Tools/SendDirectMessageTool.cs
- src/HotBox.Mcp/Tools/ReadMessagesTool.cs
- src/HotBox.Mcp/Tools/ReadDirectMessagesTool.cs
- src/HotBox.Mcp/Tools/ListAgentAccountsTool.cs
- src/HotBox.Mcp/Tools/CreateAgentAccountTool.cs
- src/HotBox.Application/DependencyInjection/ApplicationServiceExtensions.cs

Closes #160