### PR TITLE
feat: add MCP tool for channel lookup (#161)

### DIFF
--- a/src/HotBox.Mcp/Clients/HotBoxApiClient.cs
+++ b/src/HotBox.Mcp/Clients/HotBoxApiClient.cs
@@ -114,6 +114,26 @@ public class HotBoxApiClient
     }
 
     /// <summary>
+    /// Lists all channels (requires bearer token auth).
+    /// </summary>
+    public async Task<JsonElement> ListChannelsAsync(string bearerToken, CancellationToken cancellationToken = default)
+    {
+        var request = new HttpRequestMessage(HttpMethod.Get, "/api/channels");
+        request.Headers.Authorization = new AuthenticationHeaderValue("Bearer", bearerToken);
+
+        var response = await _httpClient.SendAsync(request, cancellationToken);
+        if (!response.IsSuccessStatusCode)
+        {
+            var errorBody = await response.Content.ReadAsStringAsync(cancellationToken);
+            throw new HttpRequestException(
+                $"Response status code does not indicate success: {(int)response.StatusCode} ({response.ReasonPhrase}). Body: {errorBody}",
+                null,
+                response.StatusCode);
+        }
+        return await response.Content.ReadFromJsonAsync<JsonElement>(cancellationToken);
+    }
+
+    /// <summary>
     /// Reads direct messages with a user (requires bearer token auth).
     /// </summary>
     public async Task<JsonElement> ReadDirectMessagesAsync(Guid userId, int limit, string bearerToken, CancellationToken cancellationToken = default)

--- a/src/HotBox.Mcp/Tools/ReadChannelsTool.cs
+++ b/src/HotBox.Mcp/Tools/ReadChannelsTool.cs
@@ -1,0 +1,52 @@
+using System.ComponentModel;
+using System.Text.Json;
+using HotBox.Mcp.Clients;
+using ModelContextProtocol.Server;
+
+namespace HotBox.Mcp.Tools;
+
+[McpServerToolType]
+public static class ReadChannelsTool
+{
+    [McpServerTool]
+    [Description("Lists all channels in HotBox. Optionally filter by name. Requires the agent's bearer token.")]
+    public static async Task<string> ReadChannels(
+        [Description("Optional channel name filter. Case-insensitive partial match.")] string nameFilter = "",
+        [Description("The agent's JWT bearer token for authentication")] string bearerToken = "",
+        HotBoxApiClient? client = null)
+    {
+        // Input validation
+        if (string.IsNullOrWhiteSpace(bearerToken))
+        {
+            return "Error: bearerToken cannot be empty";
+        }
+
+        if (client == null)
+        {
+            return "Error: client cannot be null";
+        }
+
+        try
+        {
+            var result = await client.ListChannelsAsync(bearerToken);
+
+            // Apply client-side name filter if provided
+            if (!string.IsNullOrWhiteSpace(nameFilter))
+            {
+                var channels = result.EnumerateArray()
+                    .Where(c => c.TryGetProperty("name", out var name) &&
+                                name.GetString()?.Contains(nameFilter, StringComparison.OrdinalIgnoreCase) == true)
+                    .ToList();
+
+                return JsonSerializer.Serialize(channels, new JsonSerializerOptions { WriteIndented = true });
+            }
+
+            return JsonSerializer.Serialize(result, new JsonSerializerOptions { WriteIndented = true });
+        }
+        catch (HttpRequestException ex)
+        {
+            var statusCode = ex.StatusCode != null ? $"HTTP {(int)ex.StatusCode}" : "HTTP error";
+            return $"Error: {statusCode} - {ex.Message}";
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Adds a new MCP tool for listing and filtering channels:
- Created `ReadChannelsTool` that lists all channels with optional case-insensitive name filtering
- Added `ListChannelsAsync` method to `HotBoxApiClient` calling `GET /api/channels`
- Name filter applied client-side via LINQ (appropriate for small-scale deployment)
- Tool auto-discovered via `WithToolsFromAssembly()` — no manual registration needed

## Files Changed
- `src/HotBox.Mcp/Tools/ReadChannelsTool.cs` (new)
- `src/HotBox.Mcp/Clients/HotBoxApiClient.cs` (modified)

## Review Status
- Code Review: APPROVED (no critical/major issues)
- UI Review: SKIPPED (no UI changes)
- Unresolved items: none

Closes #161

🤖 Generated with [Claude Code](https://claude.com/claude-code)