### PR TITLE
feat: add user profile DTOs, API endpoints, and client methods

### DIFF
--- a/src/HotBox.Application/Models/UpdateProfileRequest.cs
+++ b/src/HotBox.Application/Models/UpdateProfileRequest.cs
@@ -1,0 +1,23 @@
+using System.ComponentModel.DataAnnotations;
+
+namespace HotBox.Application.Models;
+
+public class UpdateProfileRequest
+{
+    [Required]
+    [MaxLength(100)]
+    public string DisplayName { get; set; } = string.Empty;
+
+    [MaxLength(500)]
+    [Url]
+    public string? AvatarUrl { get; set; }
+
+    [MaxLength(256)]
+    public string? Bio { get; set; }
+
+    [MaxLength(50)]
+    public string? Pronouns { get; set; }
+
+    [MaxLength(128)]
+    public string? CustomStatus { get; set; }
+}

--- a/src/HotBox.Application/Models/UserProfileResponse.cs
+++ b/src/HotBox.Application/Models/UserProfileResponse.cs
@@ -1,0 +1,16 @@
+namespace HotBox.Application.Models;
+
+public class UserProfileResponse
+{
+    public Guid Id { get; set; }
+    public string DisplayName { get; set; } = string.Empty;
+    public string? AvatarUrl { get; set; }
+    public string? Bio { get; set; }
+    public string? Pronouns { get; set; }
+    public string? CustomStatus { get; set; }
+    public string Status { get; set; } = string.Empty;
+    public string Role { get; set; } = string.Empty;
+    public DateTime CreatedAtUtc { get; set; }
+    public DateTime LastSeenUtc { get; set; }
+    public bool IsAgent { get; set; }
+}

--- a/src/HotBox.Client/Models/UpdateProfileRequest.cs
+++ b/src/HotBox.Client/Models/UpdateProfileRequest.cs
@@ -1,0 +1,14 @@
+namespace HotBox.Client.Models;
+
+public class UpdateProfileRequest
+{
+    public string DisplayName { get; set; } = string.Empty;
+
+    public string? AvatarUrl { get; set; }
+
+    public string? Bio { get; set; }
+
+    public string? Pronouns { get; set; }
+
+    public string? CustomStatus { get; set; }
+}

--- a/src/HotBox.Client/Models/UserProfileResponse.cs
+++ b/src/HotBox.Client/Models/UserProfileResponse.cs
@@ -1,0 +1,26 @@
+namespace HotBox.Client.Models;
+
+public class UserProfileResponse
+{
+    public Guid Id { get; set; }
+
+    public string DisplayName { get; set; } = string.Empty;
+
+    public string? AvatarUrl { get; set; }
+
+    public string? Bio { get; set; }
+
+    public string? Pronouns { get; set; }
+
+    public string? CustomStatus { get; set; }
+
+    public string Status { get; set; } = string.Empty;
+
+    public string Role { get; set; } = string.Empty;
+
+    public DateTime CreatedAtUtc { get; set; }
+
+    public DateTime LastSeenUtc { get; set; }
+
+    public bool IsAgent { get; set; }
+}

--- a/src/HotBox.Client/Services/ApiClient.cs
+++ b/src/HotBox.Client/Services/ApiClient.cs
@@ -269,6 +269,23 @@ public class ApiClient
         return await GetAsync<List<UserSearchResult>>(url, ct) ?? new List<UserSearchResult>();
     }
 
+    public async Task<UserProfileResponse?> GetMyProfileAsync(CancellationToken ct = default)
+    {
+        return await GetAsync<UserProfileResponse>("api/users/me", ct);
+    }
+
+    public async Task<UserProfileResponse?> GetUserProfileAsync(Guid userId, CancellationToken ct = default)
+    {
+        return await GetAsync<UserProfileResponse>($"api/users/{userId}", ct);
+    }
+
+    public async Task<UserProfileResponse?> UpdateMyProfileAsync(
+        UpdateProfileRequest request,
+        CancellationToken ct = default)
+    {
+        return await PutReturningAsync<UserProfileResponse>("api/users/me", request, ct);
+    }
+
     // ── Search ────────────────────────────────────────────────────────────
 
     public async Task<SearchResultModel?> SearchMessagesAsync(


### PR DESCRIPTION
## Summary

This PR implements the server-side DTOs, API endpoints, client models, and API client methods for user profiles (part of Epic #122).

### Changes Included

**#126: Server DTOs**
- Created `UserProfileResponse` DTO with all profile fields (Id, DisplayName, AvatarUrl, Bio, Pronouns, CustomStatus, Status, Role, CreatedAtUtc, LastSeenUtc, IsAgent)
- Created `UpdateProfileRequest` DTO with validation attributes (Required, MaxLength, Url)

**#127: UsersController Endpoints**
- Added GET /api/users/me — returns authenticated user's profile
- Added GET /api/users/{id} — returns any user's profile (or 404)
- Added PUT /api/users/me — updates authenticated user's own profile
- Added GET /api/users — returns list of all users
- Added MapToResponse helper for AppUser → UserProfileResponse mapping
- All endpoints require authentication via existing [Authorize] attribute

**#128: Client Models**
- Created client-side UserProfileResponse (mirrors server DTO, no validation)
- Created client-side UpdateProfileRequest (mirrors server DTO, no validation)

**#129: ApiClient Methods**
- Added GetMyProfileAsync() — GET /api/users/me
- Added GetUserProfileAsync(Guid userId) — GET /api/users/{id}
- Added UpdateMyProfileAsync(UpdateProfileRequest) — PUT /api/users/me

### Files Changed
- src/HotBox.Application/Models/UserProfileResponse.cs (new)
- src/HotBox.Application/Models/UpdateProfileRequest.cs (new)
- src/HotBox.Application/Controllers/UsersController.cs (modified)
- src/HotBox.Client/Models/UserProfileResponse.cs (new)
- src/HotBox.Client/Models/UpdateProfileRequest.cs (new)
- src/HotBox.Client/Services/ApiClient.cs (modified)

### Review Status
- Code Review: APPROVED after 1 fix iteration (removed unused ILogger, added IsAgent field)
- UI Review: SKIPPED (no UI files changed)
- Unresolved items: none

Closes #126, closes #127, closes #128, closes #129

🤖 Generated with [Claude Code](https://claude.com/claude-code)