### PR TITLE
docs: comprehensive documentation audit and update

### DIFF
--- a/.claude/agents/auth-security.md
+++ b/.claude/agents/auth-security.md
@@ -19,20 +19,23 @@ You own everything related to identity, authentication, authorization, and acces
 ## Code You Own
 
 ```
-src/HotBox.Infrastructure/Identity/       # AppUser.cs, identity configuration
+src/HotBox.Core/Entities/AppUser.cs       # User entity with profile fields
+src/HotBox.Core/Entities/ApiKey.cs        # API key entity for agents
+src/HotBox.Core/Options/AdminSeedOptions.cs
+src/HotBox.Core/Interfaces/ITokenService.cs
 src/HotBox.Infrastructure/Data/Seeding/   # DatabaseSeeder.cs
+src/HotBox.Infrastructure/Services/TokenService.cs
 src/HotBox.Application/Controllers/AuthController.cs
 src/HotBox.Application/Controllers/AdminController.cs
-src/HotBox.Application/Extensions/AuthenticationExtensions.cs
-src/HotBox.Application/Services/ITokenService.cs
-src/HotBox.Application/Services/TokenService.cs
+src/HotBox.Application/Controllers/AgentsController.cs
+src/HotBox.Application/Authentication/ApiKeyAuthenticationHandler.cs
 ```
 
 ## Code You Influence But Don't Own
 
-- `HotBox.Application/Configuration/AuthOptions.cs`, `JwtOptions.cs`, `OAuthProviderOptions.cs` — owned by Platform, you define what goes in them
+- `HotBox.Core/Options/JwtOptions.cs`, `OAuthOptions.cs` — owned by Platform, you define what goes in them
 - `ChatHub.cs`, `VoiceSignalingHub.cs` — owned by Messaging / Real-time, but you define the authorization rules applied to them
-- `HotBox.Client/Components/Auth/` — owned by Client Experience, but you define the auth flow they implement
+- `HotBox.Client/Pages/Login.razor`, `Register.razor` — owned by Client Experience, but you define the auth flow they implement
 - `HotBox.Client/Services/AuthService.cs`, `AuthState.cs` — owned by Client Experience, but you define the token management behavior
 
 ## Documentation You Maintain
@@ -81,12 +84,10 @@ The `/api/v1/auth/providers` endpoint returns enabled providers. The login UI re
 On first run (no admin exists), create admin from config:
 ```json
 {
-  "Auth": {
-    "Seed": {
-      "AdminEmail": "admin@hotbox.local",
-      "AdminPassword": "ChangeMe123!",
-      "AdminDisplayName": "Admin"
-    }
+  "AdminSeed": {
+    "Email": "admin@hotbox.local",
+    "Password": "ChangeMe123!",
+    "DisplayName": "Admin"
   }
 }
 ```
@@ -123,7 +124,7 @@ On first run (no admin exists), create admin from config:
 - Access tokens: short-lived (15 min), never in localStorage
 - Refresh tokens: HttpOnly + Secure + SameSite=Strict cookie
 - All auth endpoints rate-limited
-- JWT secret must be at least 64 characters in production
+- JWT secret must be at least 32 characters in production
 - OAuth client secrets stored in environment variables, never in committed config
 
 ## Coordination Points

--- a/.claude/agents/client-experience.md
+++ b/.claude/agents/client-experience.md
@@ -26,77 +26,63 @@ You own the entire Blazor WASM client shell and the holistic user experience:
 ```
 # Layout
 src/HotBox.Client/Layout/MainLayout.razor
-src/HotBox.Client/Layout/MainLayout.razor.css
+src/HotBox.Client/Layout/AuthLayout.razor
+src/HotBox.Client/Layout/AdminLayout.razor
 
-# Sidebar
-src/HotBox.Client/Components/Sidebar/Sidebar.razor
-src/HotBox.Client/Components/Sidebar/ServerHeader.razor
-src/HotBox.Client/Components/Sidebar/ChannelList.razor
-src/HotBox.Client/Components/Sidebar/ChannelItem.razor
-src/HotBox.Client/Components/Sidebar/DirectMessageList.razor
-src/HotBox.Client/Components/Sidebar/DirectMessageItem.razor
-src/HotBox.Client/Components/Sidebar/UserPanel.razor
+# Pages
+src/HotBox.Client/Pages/Login.razor
+src/HotBox.Client/Pages/Register.razor
+src/HotBox.Client/Pages/Channel.razor
+src/HotBox.Client/Pages/DirectMessage.razor
+src/HotBox.Client/Pages/Admin.razor
 
-# Chat
-src/HotBox.Client/Components/Chat/ChatView.razor
+# Chat Components
+src/HotBox.Client/Components/Chat/ChannelList.razor
+src/HotBox.Client/Components/Chat/DirectMessageList.razor
 src/HotBox.Client/Components/Chat/ChannelHeader.razor
 src/HotBox.Client/Components/Chat/MessageList.razor
-src/HotBox.Client/Components/Chat/MessageGroup.razor
+src/HotBox.Client/Components/Chat/DirectMessageMessageList.razor
 src/HotBox.Client/Components/Chat/MessageInput.razor
+src/HotBox.Client/Components/Chat/DirectMessageInput.razor
 src/HotBox.Client/Components/Chat/TypingIndicator.razor
+src/HotBox.Client/Components/Chat/MembersPanel.razor
 
-# Members
-src/HotBox.Client/Components/Members/MembersPanel.razor
-src/HotBox.Client/Components/Members/MemberItem.razor
+# Profile Components
+src/HotBox.Client/Components/Profile/EditProfileModal.razor
+src/HotBox.Client/Components/Profile/UserProfilePopover.razor
 
-# Auth
-src/HotBox.Client/Components/Auth/LoginPage.razor
-src/HotBox.Client/Components/Auth/RegisterPage.razor
-src/HotBox.Client/Components/Auth/OAuthButtons.razor
+# Admin Components
+src/HotBox.Client/Components/Admin/AdminServerSettings.razor
+src/HotBox.Client/Components/Admin/AdminChannelManagement.razor
+src/HotBox.Client/Components/Admin/AdminUserManagement.razor
+src/HotBox.Client/Components/Admin/AdminInviteManagement.razor
+src/HotBox.Client/Components/Admin/AdminApiKeyManagement.razor
 
-# Admin
-src/HotBox.Client/Components/Admin/AdminPanel.razor
-src/HotBox.Client/Components/Admin/ChannelManagement.razor
-src/HotBox.Client/Components/Admin/UserManagement.razor
-src/HotBox.Client/Components/Admin/InviteManagement.razor
-src/HotBox.Client/Components/Admin/ServerSettings.razor
-
-# Search
-src/HotBox.Client/Components/Search/SearchOverlay.razor
-src/HotBox.Client/Components/Search/SearchOverlay.razor.css
-src/HotBox.Client/Components/Search/SearchInput.razor
-src/HotBox.Client/Components/Search/SearchResults.razor
-src/HotBox.Client/Components/Search/SearchResultItem.razor
-src/HotBox.Client/Components/Search/SearchHighlight.razor
-src/HotBox.Client/State/SearchState.cs
-src/HotBox.Client/Models/SearchResultDto.cs
-src/HotBox.Client/Models/SearchResponse.cs
-
-# Shared
-src/HotBox.Client/Components/Shared/Avatar.razor
-src/HotBox.Client/Components/Shared/StatusDot.razor
-src/HotBox.Client/Components/Shared/UnreadBadge.razor
-src/HotBox.Client/Components/Shared/LoadingSpinner.razor
-src/HotBox.Client/Components/Shared/ErrorBoundary.razor
+# Shared Components
+src/HotBox.Client/Components/SearchOverlay.razor
+src/HotBox.Client/Components/NewDmPicker.razor
+src/HotBox.Client/Components/ConnectionStatus.razor
+src/HotBox.Client/Components/GlobalErrorBoundary.razor
 
 # Services
-src/HotBox.Client/Services/IApiClient.cs
 src/HotBox.Client/Services/ApiClient.cs
-src/HotBox.Client/Services/IAuthService.cs
-src/HotBox.Client/Services/AuthService.cs
-src/HotBox.Client/Services/IChatHubService.cs
 src/HotBox.Client/Services/ChatHubService.cs
-src/HotBox.Client/Services/INotificationService.cs
 src/HotBox.Client/Services/NotificationService.cs
+src/HotBox.Client/Services/JwtParser.cs
 
 # State
 src/HotBox.Client/State/AppState.cs
 src/HotBox.Client/State/ChannelState.cs
+src/HotBox.Client/State/DirectMessageState.cs
 src/HotBox.Client/State/AuthState.cs
 src/HotBox.Client/State/PresenceState.cs
+src/HotBox.Client/State/SearchState.cs
 
 # Models / DTOs
 src/HotBox.Client/Models/
+
+# Dependency Injection
+src/HotBox.Client/DependencyInjection/ClientServiceExtensions.cs
 
 # Styles
 src/HotBox.Client/wwwroot/css/app.css
@@ -116,40 +102,41 @@ tests/HotBox.Client.Tests/
 
 ## Code You Don't Own (But Integrate With)
 
-- `VoiceChannelItem.razor`, `VoiceUserList.razor`, `VoiceConnectedPanel.razor` — owned by Real-time & Media (these plug into your sidebar layout)
 - `webrtc-interop.js`, `audio-interop.js` — owned by Real-time & Media
-- `VoiceHubService.cs`, `WebRtcService.cs`, `VoiceState.cs` — owned by Real-time & Media
+- `VoiceHubService.cs`, `WebRtcService.cs`, `VoiceConnectionManager.cs`, `VoiceState.cs` — owned by Real-time & Media
 - Server-side controllers, hubs, services — owned by their respective domains
 
 ## Documentation You Maintain
 
 - `docs/technical-spec.md` — Section 3 (Frontend Architecture), design tokens table (Section 3.5)
 - `docs/implementation-plan.md` — Phase 7 (Auth UI), Phase 8 (Admin Panel)
-- UI prototype at `temp/prototype.html`
+- UI prototypes at `prototypes/main-ui-proposal.html` and other files in `prototypes/`
 
 ## Design System
 
 ### Design Tokens (CSS Custom Properties)
 
-These are defined in `wwwroot/css/app.css` and derived from the prototype at `temp/prototype.html`:
+These are defined in `wwwroot/css/app.css` and derived from the prototype at `prototypes/main-ui-proposal.html`:
 
 | Token | Value | Usage |
 |-------|-------|-------|
-| `--bg-deepest` | `#1a1a1e` | Outermost background, user panel |
-| `--bg-deep` | `#1e1e23` | Sidebar, members panel |
-| `--bg-base` | `#232329` | Main content area |
-| `--bg-raised` | `#2a2a32` | Message input, cards |
-| `--bg-surface` | `#32323c` | Avatars, elevated surfaces |
-| `--bg-hover` | `#3a3a46` | Hover states |
-| `--bg-active` | `#424250` | Active/selected states |
-| `--text-primary` | `#e4e4e8` | Primary text |
-| `--text-secondary` | `#a0a0aa` | Secondary text, message bodies |
-| `--text-muted` | `#6e6e7a` | Timestamps, hints |
-| `--accent` | `#7aa2f7` | Links, active indicators |
-| `--status-online` | `#50c878` | Online status dot |
-| `--status-idle` | `#e2b93d` | Idle status dot |
-| `--status-dnd` | `#f7768e` | Do Not Disturb status dot |
-| `--status-offline` | `#565664` | Offline status dot |
+| `--bg-deepest` | `#0c0c0f` | Outermost background, user panel |
+| `--bg-deep` | `#111116` | Sidebar, members panel |
+| `--bg-base` | `#16161d` | Main content area |
+| `--bg-raised` | `#1c1c25` | Message input, cards |
+| `--bg-surface` | `#23232e` | Avatars, elevated surfaces |
+| `--bg-hover` | `#2a2a37` | Hover states |
+| `--bg-active` | `#32323f` | Active/selected states |
+| `--text-primary` | `#e2e2ea` | Primary text |
+| `--text-secondary` | `#9898a8` | Secondary text, message bodies |
+| `--text-muted` | `#5c5c72` | Timestamps, hints |
+| `--text-faint` | `#3e3e52` | Very subtle text |
+| `--accent` | `#5de4c7` | Links, active indicators (cool teal) |
+| `--accent-hover` | `#7aecd5` | Accent hover state |
+| `--status-online` | `#6bc76b` | Online status dot |
+| `--status-idle` | `#c7a63e` | Idle status dot |
+| `--status-dnd` | `#c76060` | Do Not Disturb status dot |
+| `--status-offline` | `#4a4a5a` | Offline status dot |
 
 ### Design Principles
 
@@ -162,15 +149,17 @@ These are defined in `wwwroot/css/app.css` and derived from the prototype at `te
 
 ### Layout
 
-Three-panel layout (based on prototype):
+Top-bar layout with left sidebar (based on prototype):
 ```
-+----------+------------------+----------+
-|          |                  |          |
-| Sidebar  |    Chat Area     | Members  |
-| (240px)  |    (flexible)    | (240px)  |
-|          |                  |(toggle)  |
-|          |                  |          |
-+----------+------------------+----------+
++-----------------------------------------------+
+|  Top Bar (channels/DMs, server name)         |
++----------+------------------------------------+
+|          |                                    |
+| Members  |          Chat Area                 |
+| Panel    |          (flexible)                |
+| (240px)  |                                    |
+| (toggle) |                                    |
++----------+------------------------------------+
 ```
 
 ## State Management Pattern

--- a/.claude/agents/messaging.md
+++ b/.claude/agents/messaging.md
@@ -21,7 +21,6 @@ src/HotBox.Infrastructure/Repositories/ChannelRepository.cs
 src/HotBox.Infrastructure/Repositories/MessageRepository.cs
 src/HotBox.Infrastructure/Repositories/DirectMessageRepository.cs
 src/HotBox.Infrastructure/Repositories/InviteRepository.cs
-src/HotBox.Infrastructure/Repositories/UserRepository.cs
 
 # Controllers
 src/HotBox.Application/Controllers/ChannelsController.cs
@@ -33,29 +32,31 @@ src/HotBox.Application/Hubs/ChatHub.cs
 
 # Search
 src/HotBox.Application/Controllers/SearchController.cs
-src/HotBox.Application/Services/ISearchService.cs
-src/HotBox.Application/Services/SearchService.cs
-src/HotBox.Infrastructure/Search/PostgresSearchService.cs
-src/HotBox.Infrastructure/Search/MySqlSearchService.cs
-src/HotBox.Infrastructure/Search/SqliteSearchService.cs
-src/HotBox.Infrastructure/Search/FallbackSearchService.cs
+src/HotBox.Core/Interfaces/ISearchService.cs
+src/HotBox.Infrastructure/Services/Search/SearchService.cs
+src/HotBox.Infrastructure/Services/Search/PostgresSearchService.cs
+src/HotBox.Infrastructure/Services/Search/MySqlSearchService.cs
+src/HotBox.Infrastructure/Services/Search/SqliteSearchService.cs
+src/HotBox.Infrastructure/Services/Search/FallbackSearchService.cs
 
 # Services
-src/HotBox.Application/Services/IChannelService.cs
-src/HotBox.Application/Services/ChannelService.cs
-src/HotBox.Application/Services/IMessageService.cs
-src/HotBox.Application/Services/MessageService.cs
-src/HotBox.Application/Services/IDirectMessageService.cs
-src/HotBox.Application/Services/DirectMessageService.cs
+src/HotBox.Core/Interfaces/IChannelService.cs
+src/HotBox.Infrastructure/Services/ChannelService.cs
+src/HotBox.Core/Interfaces/IMessageService.cs
+src/HotBox.Infrastructure/Services/MessageService.cs
+src/HotBox.Core/Interfaces/IDirectMessageService.cs
+src/HotBox.Infrastructure/Services/DirectMessageService.cs
+src/HotBox.Application/Services/NotificationService.cs
 ```
 
 ## Code You Influence But Don't Own
 
 - Core entities (`Channel.cs`, `Message.cs`, `DirectMessage.cs`) — owned by Platform, you propose changes
-- EF Core entity configurations — owned by Platform, you specify indexing and relationship requirements
+- EF Core entity configurations in `Infrastructure/Data/Configuration/` — owned by Platform, you specify indexing and relationship requirements
+- `Infrastructure/DependencyInjection/InfrastructureServiceExtensions.cs` — owned by Platform, you specify which services to register
 - Chat UI components (`ChatView.razor`, `MessageList.razor`, etc.) — owned by Client Experience
 - `ChatHubService.cs` (client-side SignalR service) — owned by Client Experience
-- `ChannelState.cs` (client-side state) — owned by Client Experience
+- `ChannelState.cs`, `DirectMessageState.cs` (client-side state) — owned by Client Experience
 
 ## Documentation You Maintain
 

--- a/.claude/agents/platform.md
+++ b/.claude/agents/platform.md
@@ -20,25 +20,30 @@ You own the foundational infrastructure that every other domain builds on:
 ## Code You Own
 
 ```
-src/HotBox.Core/                          # ALL files — entities, enums, interfaces
-src/HotBox.Infrastructure/Data/           # DbContext, configurations, migrations
-src/HotBox.Infrastructure/Extensions/     # InfrastructureServiceExtensions.cs
-src/HotBox.Application/Configuration/     # ALL Options classes
-src/HotBox.Application/Extensions/        # ApplicationServiceExtensions.cs, ObservabilityExtensions.cs
-src/HotBox.Application/Middleware/         # RequestLoggingMiddleware, etc.
-src/HotBox.Application/Program.cs         # Startup pipeline
+src/HotBox.Core/                                    # ALL files — entities, enums, interfaces, Options
+src/HotBox.Core/Entities/                           # AppUser.cs, ApiKey.cs, RefreshToken.cs, ServerSettings.cs, etc.
+src/HotBox.Core/Models/                             # ALL shared models
+src/HotBox.Core/Options/                            # ALL Options classes (JwtOptions, IceServerOptions, AdminSeedOptions, etc.)
+src/HotBox.Infrastructure/Data/                     # DbContext, configurations, migrations
+src/HotBox.Infrastructure/DependencyInjection/      # InfrastructureServiceExtensions.cs
+src/HotBox.Application/DependencyInjection/         # ApplicationServiceExtensions.cs, ObservabilityExtensions.cs
+src/HotBox.Application/Middleware/                  # RequestLoggingMiddleware, etc.
+src/HotBox.Application/Program.cs                   # Startup pipeline
 src/HotBox.Application/appsettings.json
 src/HotBox.Application/appsettings.Development.json
-docker/                                    # Dockerfile, docker-compose files, .env.example
+Dockerfile                                          # Multi-stage build (repo root)
+docker-compose.yml                                  # Production compose (repo root)
+docker-compose.dev.yml                              # Development compose with Seq (repo root)
+.env.example                                        # Environment variables (repo root)
 tests/HotBox.Core.Tests/
 tests/HotBox.Infrastructure.Tests/
 ```
 
 ## Code You Don't Own
 
-- Controllers, Hubs, Services in `HotBox.Application` (owned by Messaging, Auth, Real-time)
+- Controllers, Hubs in `HotBox.Application` (owned by Messaging, Auth, Real-time)
+- Service implementations in `HotBox.Infrastructure/Services/` (owned by Messaging, Auth, Real-time)
 - Anything in `HotBox.Client/` (owned by Client Experience, Messaging, Real-time)
-- Identity-specific code in `HotBox.Infrastructure/Identity/` (owned by Auth & Security)
 - Repository implementations in `HotBox.Infrastructure/Repositories/` (owned by Messaging)
 
 ## Documentation You Maintain

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -8,14 +8,14 @@ You are primarily an orchestrator (unless the user specifies otherwise). Try to 
 
 HotBox is an open-source, self-hosted alternative to Discord. Built for small friend groups (~10 people) who want a private, lightweight chat platform they fully control. Design target is ~100 concurrent users max.
 
-**Status**: Early development — solution scaffolded with Core/Infrastructure/Application/Client projects, EF Core multi-provider DbContext implemented, deployment scripts and guides in place. No application-layer features yet.
+**Status**: Active development — Core/Infrastructure/Application/Client projects scaffolded with EF Core multi-provider DbContext. Implemented features: authentication (JWT + OAuth + API keys), text channels, direct messages, message search (FTS), admin panel, presence/online status, voice signaling (WebRTC P2P full mesh), user profiles, MCP agent accounts. Deployment scripts and guides in place.
 
 ## Tech Stack
 
 | Layer | Technology |
 |-------|-----------|
 | Backend | ASP.NET Core (API + SignalR for real-time text) |
-| Voice | WebRTC (implementation approach TBD) |
+| Voice | WebRTC P2P full mesh (SIPSorcery signaling via SignalR, JS interop for browser WebRTC) |
 | Web Client | Blazor WASM (no JS frameworks, no JS on the server — ever) |
 | Database | SQLite (dev), PostgreSQL/MySQL/MariaDB (prod) via EF Core |
 | Auth | ASP.NET Identity + optional OAuth (Google, Microsoft) |

--- a/docs/architecture/configuration-reference.md
+++ b/docs/architecture/configuration-reference.md
@@ -1,0 +1,295 @@
+# Configuration Reference
+
+Authoritative reference for all HotBox configuration sections. All configuration uses the ASP.NET Core Options pattern with classes in `HotBox.Core/Options/`.
+
+## Configuration Sources
+
+Configuration is loaded from (in priority order):
+
+1. Environment variables (using `__` as section separator, e.g., `Server__ServerName`)
+2. `appsettings.{Environment}.json`
+3. `appsettings.json`
+
+## Sections
+
+### Server
+
+- **Options class**: `ServerOptions` (`HotBox.Core/Options/ServerOptions.cs`)
+- **Config section**: `Server`
+
+| Property | Type | Default | Description |
+|----------|------|---------|-------------|
+| `ServerName` | `string` | `"HotBox"` | Display name of the server instance |
+| `Port` | `int` | `5000` | Port number for the application to listen on |
+| `RegistrationMode` | `RegistrationMode` | `InviteOnly` | User registration mode: `Open`, `InviteOnly`, or `Closed` |
+
+**Valid RegistrationMode values**:
+- `Open` - Anyone can create an account
+- `InviteOnly` - Users need an invite code to register
+- `Closed` - Registration is disabled
+
+### Database
+
+- **Options class**: `DatabaseOptions` (`HotBox.Core/Options/DatabaseOptions.cs`)
+- **Config section**: `Database`
+
+| Property | Type | Default | Description |
+|----------|------|---------|-------------|
+| `Provider` | `string` | `"sqlite"` | Database provider: `sqlite`, `postgresql`, `mysql`, or `mariadb` |
+| `ConnectionString` | `string` | `""` | ADO.NET connection string for the selected provider |
+
+**Example connection strings**:
+- SQLite: `Data Source=hotbox.db`
+- PostgreSQL: `Host=localhost;Port=5432;Database=hotbox;Username=hotbox;Password=secret`
+- MySQL/MariaDB: `Server=localhost;Port=3306;Database=hotbox;User=hotbox;Password=secret`
+
+### Jwt
+
+- **Options class**: `JwtOptions` (`HotBox.Core/Options/JwtOptions.cs`)
+- **Config section**: `Jwt`
+
+| Property | Type | Default | Description |
+|----------|------|---------|-------------|
+| `Secret` | `string` | `""` | Secret key for signing JWT tokens (must be at least 32 characters) |
+| `Issuer` | `string` | `"HotBox"` | JWT issuer claim |
+| `Audience` | `string` | `"HotBox"` | JWT audience claim |
+| `AccessTokenExpiration` | `TimeSpan` | `00:15:00` | Access token lifetime (default: 15 minutes) |
+| `RefreshTokenExpiration` | `TimeSpan` | `7.00:00:00` | Refresh token lifetime (default: 7 days) |
+
+**TimeSpan format**: `d.hh:mm:ss` or `hh:mm:ss` (e.g., `7.00:00:00` = 7 days, `00:15:00` = 15 minutes)
+
+**Security note**: The `Secret` must be a strong random string of at least 32 characters in production. Generate with:
+```bash
+openssl rand -base64 48
+```
+
+### OAuth
+
+- **Options class**: `OAuthOptions` and `OAuthProviderOptions` (`HotBox.Core/Options/OAuthOptions.cs`)
+- **Config section**: `OAuth`
+
+#### OAuth.Google
+
+| Property | Type | Default | Description |
+|----------|------|---------|-------------|
+| `ClientId` | `string` | `""` | Google OAuth 2.0 client ID |
+| `ClientSecret` | `string` | `""` | Google OAuth 2.0 client secret |
+| `Enabled` | `bool` | `false` | Enable Google OAuth authentication |
+
+#### OAuth.Microsoft
+
+| Property | Type | Default | Description |
+|----------|------|---------|-------------|
+| `ClientId` | `string` | `""` | Microsoft OAuth 2.0 client ID |
+| `ClientSecret` | `string` | `""` | Microsoft OAuth 2.0 client secret |
+| `Enabled` | `bool` | `false` | Enable Microsoft OAuth authentication |
+
+### IceServers
+
+- **Options class**: `IceServerOptions` (`HotBox.Core/Options/IceServerOptions.cs`)
+- **Config section**: `IceServers`
+
+| Property | Type | Default | Description |
+|----------|------|---------|-------------|
+| `StunUrls` | `string[]` | `["stun:stun.l.google.com:19302"]` | STUN server URLs for WebRTC NAT traversal |
+| `TurnUrl` | `string` | `""` | TURN server URL for relay (when direct connections fail) |
+| `TurnUsername` | `string` | `""` | TURN server username |
+| `TurnCredential` | `string` | `""` | TURN server credential/password |
+
+**Note**: STUN is sufficient for most deployments. TURN is only needed if users are behind restrictive NATs/firewalls that block peer-to-peer connections.
+
+### Observability
+
+- **Options class**: `ObservabilityOptions` (`HotBox.Core/Options/ObservabilityOptions.cs`)
+- **Config section**: `Observability`
+
+| Property | Type | Default | Description |
+|----------|------|---------|-------------|
+| `SeqUrl` | `string` | `"http://localhost:5341"` | Seq log aggregation server URL |
+| `OtlpEndpoint` | `string` | `""` | OpenTelemetry Protocol (OTLP) endpoint for traces/metrics |
+| `LogLevel` | `string` | `"Information"` | Serilog minimum log level: `Verbose`, `Debug`, `Information`, `Warning`, `Error`, `Fatal` |
+
+### AdminSeed
+
+- **Options class**: `AdminSeedOptions` (`HotBox.Core/Options/AdminSeedOptions.cs`)
+- **Config section**: `AdminSeed`
+
+| Property | Type | Default | Description |
+|----------|------|---------|-------------|
+| `Email` | `string` | `""` | Email for the default admin user (created on first run if provided) |
+| `Password` | `string` | `""` | Password for the default admin user |
+| `DisplayName` | `string` | `""` | Display name for the default admin user |
+
+**Note**: If all three values are provided and no admin user exists, one will be created during application startup. Leave blank to skip admin seeding.
+
+### Search
+
+- **Options class**: `SearchOptions` (`HotBox.Core/Options/SearchOptions.cs`)
+- **Config section**: `Search`
+
+| Property | Type | Default | Description |
+|----------|------|---------|-------------|
+| `MaxResults` | `int` | `50` | Maximum number of search results to return |
+| `DefaultLimit` | `int` | `20` | Default page size for search results |
+| `MinQueryLength` | `int` | `2` | Minimum character length for a search query |
+| `SnippetLength` | `int` | `150` | Length of text snippets in search results (characters) |
+
+**Note**: This section is optional in `appsettings.json`. If omitted, the defaults from `SearchOptions` are used.
+
+## Environment Variable Examples
+
+All configuration values can be overridden via environment variables using `__` (double underscore) as the section delimiter.
+
+### Basic Configuration
+
+```bash
+# Server settings
+Server__ServerName="My HotBox Server"
+Server__Port=5000
+Server__RegistrationMode=Open
+
+# Database (PostgreSQL)
+Database__Provider=postgresql
+Database__ConnectionString="Host=localhost;Port=5432;Database=hotbox;Username=hotbox;Password=secret"
+
+# JWT (REQUIRED in production)
+Jwt__Secret="your-super-secret-key-minimum-32-characters-long"
+Jwt__Issuer="HotBox"
+Jwt__Audience="HotBox"
+Jwt__AccessTokenExpiration="00:30:00"
+Jwt__RefreshTokenExpiration="14.00:00:00"
+```
+
+### OAuth Configuration
+
+```bash
+# Google OAuth
+OAuth__Google__ClientId="123456789-abc.apps.googleusercontent.com"
+OAuth__Google__ClientSecret="GOCSPX-..."
+OAuth__Google__Enabled=true
+
+# Microsoft OAuth
+OAuth__Microsoft__ClientId="12345678-1234-1234-1234-123456789abc"
+OAuth__Microsoft__ClientSecret="abc123..."
+OAuth__Microsoft__Enabled=true
+```
+
+### WebRTC Configuration
+
+```bash
+# STUN only (most deployments)
+IceServers__StunUrls__0="stun:stun.l.google.com:19302"
+IceServers__StunUrls__1="stun:stun1.l.google.com:19302"
+
+# TURN server (restrictive networks)
+IceServers__TurnUrl="turn:turn.example.com:3478"
+IceServers__TurnUsername="turnuser"
+IceServers__TurnCredential="turnpass"
+```
+
+### Observability
+
+```bash
+# Seq for structured logs
+Observability__SeqUrl="http://seq.example.com:5341"
+
+# OTLP for traces/metrics (Jaeger, Tempo, etc.)
+Observability__OtlpEndpoint="http://jaeger:4317"
+
+# Log level
+Observability__LogLevel=Debug
+```
+
+### Admin Seeding
+
+```bash
+# Create admin user on first run
+AdminSeed__Email="admin@example.com"
+AdminSeed__Password="SecurePassword123!"
+AdminSeed__DisplayName="Admin"
+```
+
+### Search Configuration
+
+```bash
+Search__MaxResults=100
+Search__DefaultLimit=25
+Search__MinQueryLength=3
+Search__SnippetLength=200
+```
+
+## Docker Compose Environment Example
+
+The `docker-compose.yml` file demonstrates production environment variable usage:
+
+```yaml
+services:
+  hotbox:
+    environment:
+      - ASPNETCORE_ENVIRONMENT=Production
+
+      # Database (PostgreSQL)
+      - Database__Provider=postgresql
+      - Database__ConnectionString=Host=db;Port=5432;Database=hotbox;Username=hotbox;Password=${DB_PASSWORD:-changeme}
+
+      # JWT (required)
+      - Jwt__Secret=${JWT_SECRET:-super-secret-key-change-in-production-minimum-32-chars}
+
+      # Observability
+      - Observability__SeqUrl=http://seq:5341
+
+      # Admin seed
+      - AdminSeed__Email=${ADMIN_EMAIL:-admin@hotbox.local}
+      - AdminSeed__Password=${ADMIN_PASSWORD:-Admin123!}
+      - AdminSeed__DisplayName=${ADMIN_DISPLAY_NAME:-Admin}
+```
+
+**Note**: Values like `${JWT_SECRET:-default}` use shell variable substitution with fallback defaults. In production, set these as environment variables or in a `.env` file:
+
+```bash
+# .env file for docker-compose
+DB_PASSWORD=strong-db-password
+JWT_SECRET=your-strong-jwt-secret-minimum-32-characters
+ADMIN_EMAIL=admin@yourserver.com
+ADMIN_PASSWORD=SecureAdminPassword123!
+ADMIN_DISPLAY_NAME=ServerAdmin
+```
+
+## Array Configuration in Environment Variables
+
+For array properties (like `IceServers__StunUrls`), use indexed syntax:
+
+```bash
+IceServers__StunUrls__0="stun:stun.l.google.com:19302"
+IceServers__StunUrls__1="stun:stun1.l.google.com:19302"
+IceServers__StunUrls__2="stun:stun2.l.google.com:19302"
+```
+
+In JSON configuration files, use standard JSON arrays:
+
+```json
+{
+  "IceServers": {
+    "StunUrls": [
+      "stun:stun.l.google.com:19302",
+      "stun:stun1.l.google.com:19302"
+    ]
+  }
+}
+```
+
+## Validation Notes
+
+- **Jwt.Secret** must be set and at least 32 characters for production (enforced at startup)
+- **Database.ConnectionString** must be valid for the selected provider
+- **TimeSpan** values can be specified as strings in JSON (`"00:15:00"`) or as environment variables (`Jwt__AccessTokenExpiration=00:15:00`)
+- **RegistrationMode** enum values are case-insensitive when loaded from configuration
+
+## Configuration Precedence Example
+
+Given:
+1. `appsettings.json`: `Server__Port = 5000`
+2. `appsettings.Production.json`: `Server__Port = 8080`
+3. Environment variable: `Server__Port = 9000`
+
+Result: Application uses port `9000` (environment variables have highest priority).

--- a/docs/ownership-domains.md
+++ b/docs/ownership-domains.md
@@ -1,7 +1,7 @@
 # Ownership Domains
 
-**Version**: 1.0
-**Date**: 2026-02-11
+**Version**: 1.1
+**Date**: 2026-02-13
 
 This document defines the five ownership domains for HotBox development. Each domain is owned by a dedicated agent (defined in `.claude/agents/`) responsible for implementation, maintenance, bug fixes, and documentation within their area.
 
@@ -44,15 +44,18 @@ This document defines the five ownership domains for HotBox development. Each do
 
 **Code paths**:
 ```
-src/HotBox.Core/                          # All entities, enums, interfaces
+src/HotBox.Core/Entities/                 # AppUser.cs, Channel.cs, Message.cs, DirectMessage.cs, Invite.cs, ApiKey.cs, RefreshToken.cs, ServerSettings.cs
+src/HotBox.Core/Enums/                    # All enums
+src/HotBox.Core/Interfaces/               # All repository and service interfaces
+src/HotBox.Core/Options/                  # ServerOptions.cs, DatabaseOptions.cs, JwtOptions.cs, OAuthOptions.cs, IceServerOptions.cs, ObservabilityOptions.cs, AdminSeedOptions.cs, SearchOptions.cs
 src/HotBox.Infrastructure/Data/           # DbContext, configurations, migrations
-src/HotBox.Infrastructure/Extensions/     # DI registration
-src/HotBox.Application/Configuration/     # All Options classes
-src/HotBox.Application/Extensions/        # ApplicationServiceExtensions, ObservabilityExtensions
+src/HotBox.Infrastructure/DependencyInjection/ # InfrastructureServiceExtensions.cs
+src/HotBox.Application/DependencyInjection/    # ApplicationServiceExtensions.cs, ObservabilityExtensions.cs
 src/HotBox.Application/Middleware/         # Request logging, etc.
 src/HotBox.Application/Program.cs
 src/HotBox.Application/appsettings*.json
-docker/                                    # All Docker files
+Dockerfile                                 # Multi-stage build
+docker-compose*.yml                        # Compose files at repo root
 tests/HotBox.Core.Tests/
 tests/HotBox.Infrastructure.Tests/
 ```
@@ -85,16 +88,22 @@ tests/HotBox.Infrastructure.Tests/
 
 **Code paths**:
 ```
-src/HotBox.Infrastructure/Identity/       # AppUser, identity config
+src/HotBox.Core/Entities/AppUser.cs       # User entity
+src/HotBox.Core/Entities/Invite.cs        # Invite entity
+src/HotBox.Core/Entities/ApiKey.cs        # API key entity
+src/HotBox.Core/Entities/RefreshToken.cs  # Refresh token entity
+src/HotBox.Core/Interfaces/ITokenService.cs
+src/HotBox.Core/Interfaces/IInviteService.cs
+src/HotBox.Core/Options/JwtOptions.cs
+src/HotBox.Core/Options/OAuthOptions.cs
+src/HotBox.Core/Options/AdminSeedOptions.cs
+src/HotBox.Infrastructure/Identity/       # Identity configuration
 src/HotBox.Infrastructure/Data/Seeding/   # DatabaseSeeder
+src/HotBox.Infrastructure/Services/TokenService.cs
+src/HotBox.Infrastructure/Services/InviteService.cs
 src/HotBox.Application/Controllers/AuthController.cs
 src/HotBox.Application/Controllers/AdminController.cs
-src/HotBox.Application/Extensions/AuthenticationExtensions.cs
-src/HotBox.Application/Services/ITokenService.cs
-src/HotBox.Application/Services/TokenService.cs
-src/HotBox.Application/Configuration/AuthOptions.cs
-src/HotBox.Application/Configuration/JwtOptions.cs
-src/HotBox.Application/Configuration/OAuthProviderOptions.cs
+src/HotBox.Application/DependencyInjection/AuthenticationExtensions.cs
 tests/HotBox.Application.Tests/           # Auth-related tests
 ```
 
@@ -125,27 +134,32 @@ tests/HotBox.Application.Tests/           # Auth-related tests
 
 **Code paths**:
 ```
+src/HotBox.Core/Entities/Channel.cs
+src/HotBox.Core/Entities/Message.cs
+src/HotBox.Core/Entities/DirectMessage.cs
+src/HotBox.Core/Interfaces/IChannelRepository.cs
+src/HotBox.Core/Interfaces/IMessageRepository.cs
+src/HotBox.Core/Interfaces/IDirectMessageRepository.cs
+src/HotBox.Core/Interfaces/IChannelService.cs
+src/HotBox.Core/Interfaces/IMessageService.cs
+src/HotBox.Core/Interfaces/IDirectMessageService.cs
+src/HotBox.Core/Interfaces/ISearchService.cs
+src/HotBox.Core/Options/SearchOptions.cs
 src/HotBox.Infrastructure/Repositories/ChannelRepository.cs
 src/HotBox.Infrastructure/Repositories/MessageRepository.cs
 src/HotBox.Infrastructure/Repositories/DirectMessageRepository.cs
-src/HotBox.Infrastructure/Repositories/InviteRepository.cs
-src/HotBox.Infrastructure/Search/PostgresSearchService.cs
-src/HotBox.Infrastructure/Search/MySqlSearchService.cs
-src/HotBox.Infrastructure/Search/SqliteSearchService.cs
-src/HotBox.Infrastructure/Search/FallbackSearchService.cs
+src/HotBox.Infrastructure/Services/ChannelService.cs
+src/HotBox.Infrastructure/Services/MessageService.cs
+src/HotBox.Infrastructure/Services/DirectMessageService.cs
+src/HotBox.Infrastructure/Services/Search/PostgresSearchService.cs
+src/HotBox.Infrastructure/Services/Search/MySqlSearchService.cs
+src/HotBox.Infrastructure/Services/Search/SqliteSearchService.cs
+src/HotBox.Infrastructure/Services/Search/FallbackSearchService.cs
 src/HotBox.Application/Controllers/ChannelsController.cs
 src/HotBox.Application/Controllers/MessagesController.cs
 src/HotBox.Application/Controllers/DirectMessagesController.cs
 src/HotBox.Application/Controllers/SearchController.cs
 src/HotBox.Application/Hubs/ChatHub.cs
-src/HotBox.Application/Services/IChannelService.cs
-src/HotBox.Application/Services/ChannelService.cs
-src/HotBox.Application/Services/IMessageService.cs
-src/HotBox.Application/Services/MessageService.cs
-src/HotBox.Application/Services/IDirectMessageService.cs
-src/HotBox.Application/Services/DirectMessageService.cs
-src/HotBox.Application/Services/ISearchService.cs
-src/HotBox.Application/Services/SearchService.cs
 ```
 
 **Future ownership**:
@@ -180,18 +194,15 @@ src/HotBox.Application/Services/SearchService.cs
 
 **Code paths**:
 ```
+src/HotBox.Core/Options/IceServerOptions.cs
 src/HotBox.Application/Hubs/VoiceSignalingHub.cs
-src/HotBox.Application/Configuration/VoiceOptions.cs
 src/HotBox.Client/wwwroot/js/webrtc-interop.js
 src/HotBox.Client/wwwroot/js/audio-interop.js
-src/HotBox.Client/Services/IVoiceHubService.cs
 src/HotBox.Client/Services/VoiceHubService.cs
-src/HotBox.Client/Services/IWebRtcService.cs
 src/HotBox.Client/Services/WebRtcService.cs
-src/HotBox.Client/Components/Sidebar/VoiceChannelItem.razor
-src/HotBox.Client/Components/Sidebar/VoiceUserList.razor
-src/HotBox.Client/Components/Sidebar/VoiceConnectedPanel.razor
+src/HotBox.Client/Services/VoiceConnectionManager.cs
 src/HotBox.Client/State/VoiceState.cs
+# Voice UI components TBD (not yet implemented in sidebar)
 ```
 
 **Future ownership**:
@@ -203,7 +214,7 @@ src/HotBox.Client/State/VoiceState.cs
 **Coordinates with**:
 - Platform (STUN/TURN config in appsettings, Docker coturn service)
 - Messaging (voice channels share the Channel entity with text channels)
-- Client Experience (voice UI components integrate into sidebar layout)
+- Client Experience (voice UI components will integrate into channel list and top-bar layout)
 
 ---
 
@@ -212,18 +223,19 @@ src/HotBox.Client/State/VoiceState.cs
 **Agent**: `.claude/agents/client-experience.md`
 
 **Owns**:
-- Blazor WASM project shell (`MainLayout`, routing, `Program.cs`)
+- Blazor WASM project shell (`MainLayout`, `AuthLayout`, `AdminLayout`, routing, `Program.cs`)
 - Design system (CSS custom properties/tokens, `app.css`)
-- Sidebar layout and navigation
-- Members panel
-- Shared components (`Avatar`, `StatusDot`, `UnreadBadge`, `LoadingSpinner`, `ErrorBoundary`)
-- Auth UI (login/register pages, OAuth buttons, route guards)
-- Admin panel UI
-- Search UI (Ctrl+K overlay, search input, results, highlighting, jump-to-message)
+- Top-bar navigation and layout
+- Channel list, DM list, members panel
+- Chat components (message list, message input, channel header)
+- User profile UI (popover, edit modal)
+- Auth UI (login/register pages, OAuth callback, route guards)
+- Admin panel UI (user/channel/invite/settings management)
+- Search UI (Ctrl+K overlay, search results)
 - Notification display (browser notification JSInterop)
-- Presence UI (status dots, member list updates)
-- Client-side state management framework (`AppState`, `PresenceState`, `SearchState`)
-- `ApiClient` HTTP wrapper
+- Presence UI (status dots, connection status)
+- Client-side state management (`AppState`, `ChannelState`, `DirectMessageState`, `AuthState`, `PresenceState`, `SearchState`)
+- `ApiClient` HTTP wrapper and `ChatHubService`
 - Theming (dark mode, future light mode)
 - Accessibility
 
@@ -234,33 +246,47 @@ src/HotBox.Client/State/VoiceState.cs
 
 **Code paths**:
 ```
-src/HotBox.Client/Layout/                 # MainLayout
-src/HotBox.Client/Components/Sidebar/Sidebar.razor
-src/HotBox.Client/Components/Sidebar/ServerHeader.razor
-src/HotBox.Client/Components/Sidebar/ChannelList.razor
-src/HotBox.Client/Components/Sidebar/ChannelItem.razor
-src/HotBox.Client/Components/Sidebar/DirectMessageList.razor
-src/HotBox.Client/Components/Sidebar/DirectMessageItem.razor
-src/HotBox.Client/Components/Sidebar/UserPanel.razor
-src/HotBox.Client/Components/Chat/        # All chat view components
-src/HotBox.Client/Components/Search/      # Search overlay, input, results, highlighting
-src/HotBox.Client/Components/Members/     # Members panel
-src/HotBox.Client/Components/Auth/        # Login, register, OAuth buttons
-src/HotBox.Client/Components/Admin/       # Admin panel
-src/HotBox.Client/Components/Shared/      # Reusable components
-src/HotBox.Client/Services/IApiClient.cs
+src/HotBox.Client/Layout/MainLayout.razor
+src/HotBox.Client/Layout/AuthLayout.razor
+src/HotBox.Client/Layout/AdminLayout.razor
+src/HotBox.Client/Pages/ChannelPage.razor
+src/HotBox.Client/Pages/DirectMessagePage.razor
+src/HotBox.Client/Pages/DmsPage.razor
+src/HotBox.Client/Pages/LoginPage.razor
+src/HotBox.Client/Pages/RegisterPage.razor
+src/HotBox.Client/Pages/OAuthCallbackPage.razor
+src/HotBox.Client/Pages/AdminPage.razor
+src/HotBox.Client/Components/Chat/ChannelList.razor
+src/HotBox.Client/Components/Chat/ChannelHeader.razor
+src/HotBox.Client/Components/Chat/MessageList.razor
+src/HotBox.Client/Components/Chat/MessageInput.razor
+src/HotBox.Client/Components/Chat/DirectMessageList.razor
+src/HotBox.Client/Components/Chat/DirectMessageMessageList.razor
+src/HotBox.Client/Components/Chat/DirectMessageInput.razor
+src/HotBox.Client/Components/Chat/MembersPanel.razor
+src/HotBox.Client/Components/Chat/TypingIndicator.razor
+src/HotBox.Client/Components/Admin/AdminUserManagement.razor
+src/HotBox.Client/Components/Admin/AdminChannelManagement.razor
+src/HotBox.Client/Components/Admin/AdminInviteManagement.razor
+src/HotBox.Client/Components/Admin/AdminServerSettings.razor
+src/HotBox.Client/Components/Admin/AdminApiKeyManagement.razor
+src/HotBox.Client/Components/Profile/UserProfilePopover.razor
+src/HotBox.Client/Components/Profile/EditProfileModal.razor
+src/HotBox.Client/Components/SearchOverlay.razor
+src/HotBox.Client/Components/ConnectionStatus.razor
+src/HotBox.Client/Components/NewDmPicker.razor
+src/HotBox.Client/Components/GlobalErrorBoundary.razor
 src/HotBox.Client/Services/ApiClient.cs
-src/HotBox.Client/Services/IAuthService.cs
-src/HotBox.Client/Services/AuthService.cs
-src/HotBox.Client/Services/INotificationService.cs
+src/HotBox.Client/Services/ChatHubService.cs
 src/HotBox.Client/Services/NotificationService.cs
+src/HotBox.Client/Services/JwtParser.cs
 src/HotBox.Client/State/AppState.cs
 src/HotBox.Client/State/ChannelState.cs
+src/HotBox.Client/State/DirectMessageState.cs
 src/HotBox.Client/State/AuthState.cs
 src/HotBox.Client/State/PresenceState.cs
 src/HotBox.Client/State/SearchState.cs
-src/HotBox.Client/Models/SearchResultDto.cs
-src/HotBox.Client/Models/SearchResponse.cs
+src/HotBox.Client/DependencyInjection/ClientServiceExtensions.cs
 src/HotBox.Client/wwwroot/css/            # All stylesheets
 src/HotBox.Client/wwwroot/js/notification-interop.js
 src/HotBox.Client/Program.cs
@@ -319,7 +345,7 @@ Some code is touched by multiple domains. Rules of engagement:
 |------|--------------|------------|
 | Core entities/interfaces | Platform | Propose changes via Platform |
 | `ChatHub.cs` | Messaging | Real-time & Media adds voice signaling patterns |
-| Sidebar components | Client Experience | Messaging and Real-time add their specific items |
+| Channel list components | Client Experience | Messaging and Real-time add their specific items |
 | `appsettings.json` | Platform | Each domain adds their config sections |
 | `Program.cs` (Application) | Platform | Each domain adds their DI registrations |
 | `Program.cs` (Client) | Client Experience | Each domain adds their client services |

--- a/docs/technical-spec.md
+++ b/docs/technical-spec.md
@@ -88,24 +88,45 @@ HotBox.sln
 +-- src/
 |   +-- HotBox.Core/                    # Domain layer (no dependencies)
 |   |   +-- Entities/
-|   |   |   +-- User.cs
+|   |   |   +-- AppUser.cs
 |   |   |   +-- Channel.cs
 |   |   |   +-- Message.cs
 |   |   |   +-- DirectMessage.cs
-|   |   |   +-- Role.cs
-|   |   |   +-- VoiceChannel.cs
 |   |   |   +-- Invite.cs
+|   |   |   +-- ApiKey.cs
+|   |   |   +-- RefreshToken.cs
+|   |   |   +-- ServerSettings.cs
 |   |   +-- Enums/
 |   |   |   +-- ChannelType.cs
 |   |   |   +-- RegistrationMode.cs
 |   |   |   +-- UserStatus.cs
+|   |   +-- Models/
+|   |   |   +-- SearchQuery.cs
+|   |   |   +-- SearchResult.cs
+|   |   |   +-- SearchResultItem.cs
+|   |   |   +-- ConversationSummary.cs
+|   |   +-- Options/
+|   |   |   +-- ServerOptions.cs
+|   |   |   +-- DatabaseOptions.cs
+|   |   |   +-- JwtOptions.cs
+|   |   |   +-- OAuthOptions.cs
+|   |   |   +-- IceServerOptions.cs
+|   |   |   +-- ObservabilityOptions.cs
+|   |   |   +-- AdminSeedOptions.cs
+|   |   |   +-- SearchOptions.cs
 |   |   +-- Interfaces/
 |   |   |   +-- IChannelRepository.cs
 |   |   |   +-- IMessageRepository.cs
 |   |   |   +-- IDirectMessageRepository.cs
-|   |   |   +-- IUserRepository.cs
 |   |   |   +-- IInviteRepository.cs
-|   |   |   +-- IUnitOfWork.cs
+|   |   |   +-- IChannelService.cs
+|   |   |   +-- IMessageService.cs
+|   |   |   +-- IDirectMessageService.cs
+|   |   |   +-- IInviteService.cs
+|   |   |   +-- IPresenceService.cs
+|   |   |   +-- INotificationService.cs
+|   |   |   +-- IServerSettingsService.cs
+|   |   |   +-- ITokenService.cs
 |   |   |   +-- ISearchService.cs
 |   |   +-- HotBox.Core.csproj
 |   |
@@ -113,25 +134,35 @@ HotBox.sln
 |   |   +-- Data/
 |   |   |   +-- HotBoxDbContext.cs
 |   |   |   +-- Configurations/          # EF Core Fluent API configs
-|   |   |   |   +-- UserConfiguration.cs
+|   |   |   |   +-- AppUserConfiguration.cs
 |   |   |   |   +-- ChannelConfiguration.cs
 |   |   |   |   +-- MessageConfiguration.cs
 |   |   |   |   +-- DirectMessageConfiguration.cs
+|   |   |   |   +-- ApiKeyConfiguration.cs
+|   |   |   |   +-- RefreshTokenConfiguration.cs
+|   |   |   |   +-- ServerSettingsConfiguration.cs
 |   |   |   +-- Migrations/
+|   |   |   +-- Seeding/
+|   |   |       +-- DatabaseSeeder.cs
 |   |   +-- Repositories/
 |   |   |   +-- ChannelRepository.cs
 |   |   |   +-- MessageRepository.cs
 |   |   |   +-- DirectMessageRepository.cs
-|   |   |   +-- UserRepository.cs
 |   |   |   +-- InviteRepository.cs
-|   |   +-- Search/
-|   |   |   +-- PostgresSearchService.cs
-|   |   |   +-- MySqlSearchService.cs
-|   |   |   +-- SqliteSearchService.cs
-|   |   |   +-- FallbackSearchService.cs      # SQL LIKE fallback
-|   |   +-- Identity/
-|   |   |   +-- AppUser.cs              # ASP.NET Identity user (extends IdentityUser)
-|   |   +-- Extensions/
+|   |   +-- Services/
+|   |   |   +-- ChannelService.cs
+|   |   |   +-- MessageService.cs
+|   |   |   +-- DirectMessageService.cs
+|   |   |   +-- InviteService.cs
+|   |   |   +-- PresenceService.cs
+|   |   |   +-- ServerSettingsService.cs
+|   |   |   +-- TokenService.cs
+|   |   |   +-- Search/
+|   |   |       +-- PostgresSearchService.cs
+|   |   |       +-- MySqlSearchService.cs
+|   |   |       +-- SqliteSearchService.cs
+|   |   |       +-- FallbackSearchService.cs
+|   |   +-- DependencyInjection/
 |   |   |   +-- InfrastructureServiceExtensions.cs
 |   |   +-- HotBox.Infrastructure.csproj
 |   |
@@ -144,31 +175,21 @@ HotBox.sln
 |   |   |   +-- SearchController.cs
 |   |   |   +-- UsersController.cs
 |   |   |   +-- AdminController.cs
+|   |   |   +-- AgentsController.cs
 |   |   +-- Hubs/
 |   |   |   +-- ChatHub.cs
 |   |   |   +-- VoiceSignalingHub.cs
 |   |   +-- Services/
-|   |   |   +-- IChannelService.cs
-|   |   |   +-- ChannelService.cs
-|   |   |   +-- IMessageService.cs
-|   |   |   +-- MessageService.cs
-|   |   |   +-- IDirectMessageService.cs
-|   |   |   +-- DirectMessageService.cs
-|   |   |   +-- ISearchService.cs
-|   |   |   +-- SearchService.cs
-|   |   |   +-- IPresenceService.cs
-|   |   |   +-- PresenceService.cs
-|   |   |   +-- INotificationService.cs
 |   |   |   +-- NotificationService.cs
-|   |   +-- Configuration/
-|   |   |   +-- HotBoxOptions.cs
-|   |   |   +-- AuthOptions.cs
-|   |   |   +-- OAuthProviderOptions.cs
-|   |   |   +-- DatabaseOptions.cs
-|   |   |   +-- SearchOptions.cs
-|   |   +-- Extensions/
+|   |   +-- Authentication/
+|   |   |   +-- ApiKeyAuthenticationHandler.cs
+|   |   +-- Models/
+|   |   |   +-- MessageResponse.cs
+|   |   |   +-- DirectMessageResponse.cs
+|   |   |   +-- UserResponse.cs
+|   |   |   +-- (other DTOs)
+|   |   +-- DependencyInjection/
 |   |   |   +-- ApplicationServiceExtensions.cs
-|   |   |   +-- AuthenticationExtensions.cs
 |   |   |   +-- ObservabilityExtensions.cs
 |   |   +-- Middleware/
 |   |   |   +-- RequestLoggingMiddleware.cs
@@ -186,10 +207,8 @@ HotBox.sln
 |   +-- HotBox.Application.Tests/
 |   +-- HotBox.Client.Tests/
 |
-+-- docker/
-|   +-- Dockerfile
-|   +-- docker-compose.yml
-|   +-- docker-compose.dev.yml
++-- Dockerfile
++-- docker-compose.yml
 |
 +-- docs/
 ```
@@ -197,7 +216,7 @@ HotBox.sln
 ### 2.2 Project Dependencies
 
 ```
-HotBox.Core          --> (none - zero external dependencies)
+HotBox.Core          --> Microsoft.Extensions.Identity.Stores (for IdentityUser<Guid>)
 HotBox.Infrastructure --> HotBox.Core, EF Core, ASP.NET Identity
 HotBox.Application    --> HotBox.Core, HotBox.Infrastructure, SignalR, Serilog, OpenTelemetry
 HotBox.Client         --> (standalone Blazor WASM, communicates via HTTP/SignalR)
@@ -205,72 +224,95 @@ HotBox.Client         --> (standalone Blazor WASM, communicates via HTTP/SignalR
 
 ### 2.3 API Endpoint Design
 
-All API endpoints are prefixed with `/api/v1/`.
+All API endpoints are prefixed with `/api/`.
 
 #### Authentication
 
 | Method | Route | Description |
 |--------|-------|-------------|
-| POST | `/api/v1/auth/register` | Register new user (respects registration mode) |
-| POST | `/api/v1/auth/login` | Email/password login, returns JWT |
-| POST | `/api/v1/auth/refresh` | Refresh JWT token |
-| POST | `/api/v1/auth/logout` | Invalidate refresh token |
-| GET | `/api/v1/auth/providers` | List enabled OAuth providers |
-| GET | `/api/v1/auth/external/{provider}` | Initiate OAuth flow |
-| GET | `/api/v1/auth/external/callback` | OAuth callback handler |
+| POST | `/api/auth/register` | Register new user (respects registration mode) |
+| POST | `/api/auth/login` | Email/password login, returns JWT |
+| POST | `/api/auth/refresh` | Refresh JWT token |
+| POST | `/api/auth/logout` | Invalidate refresh token |
+| GET | `/api/auth/providers` | List enabled OAuth providers |
+| GET | `/api/auth/registration-mode` | Get current registration mode |
+| GET | `/api/auth/external/{provider}` | Initiate OAuth flow |
+| GET | `/api/auth/external/callback` | OAuth callback handler |
 
 #### Channels
 
 | Method | Route | Description |
 |--------|-------|-------------|
-| GET | `/api/v1/channels` | List all channels (text + voice) |
-| POST | `/api/v1/channels` | Create channel (admin/mod) |
-| GET | `/api/v1/channels/{id}` | Get channel details |
-| PUT | `/api/v1/channels/{id}` | Update channel (admin/mod) |
-| DELETE | `/api/v1/channels/{id}` | Delete channel (admin) |
+| GET | `/api/channels` | List all channels (text + voice) |
+| POST | `/api/channels` | Create channel (admin/mod) |
+| GET | `/api/channels/{id}` | Get channel details |
+| PUT | `/api/channels/{id}` | Update channel (admin/mod) |
+| DELETE | `/api/channels/{id}` | Delete channel (admin) |
 
 #### Messages
 
 | Method | Route | Description |
 |--------|-------|-------------|
-| GET | `/api/v1/channels/{channelId}/messages` | Get message history (paginated) |
-| POST | `/api/v1/channels/{channelId}/messages` | Post message (also via SignalR) |
+| GET | `/api/channels/{channelId}/messages` | Get message history (paginated) |
+| GET | `/api/messages/{id}` | Get message by ID |
+| POST | `/api/channels/{channelId}/messages` | Post message (also via SignalR) |
 
 #### Direct Messages
 
 | Method | Route | Description |
 |--------|-------|-------------|
-| GET | `/api/v1/dm/conversations` | List DM conversations |
-| GET | `/api/v1/dm/{userId}/messages` | Get DM history (paginated) |
-| POST | `/api/v1/dm/{userId}/messages` | Send DM (also via SignalR) |
+| GET | `/api/dm` | List DM conversations |
+| GET | `/api/dm/{userId}` | Get DM history (paginated) |
+| POST | `/api/dm/{userId}` | Send DM (also via SignalR) |
 
 #### Search
 
 | Method | Route | Description |
 |--------|-------|-------------|
-| GET | `/api/v1/search/messages` | Search channel messages (query params: `q`, `channelId?`, `authorId?`, `before?`, `after?`, `page`, `pageSize`) |
-| GET | `/api/v1/search/dm` | Search direct messages (query params: `q`, `participantId?`, `before?`, `after?`, `page`, `pageSize`) |
-| POST | `/api/v1/admin/search/reindex` | Backfill search index from database (admin only) |
+| GET | `/api/search/messages` | Search channel messages (query params: `q`, `channelId?`, `senderId?`, `cursor?`, `limit`) |
+| GET | `/api/search/status` | Get search index status |
+| POST | `/api/search/reindex` | Rebuild search index from database (admin only) |
 
 #### Users
 
 | Method | Route | Description |
 |--------|-------|-------------|
-| GET | `/api/v1/users` | List users |
-| GET | `/api/v1/users/{id}` | Get user profile |
-| PUT | `/api/v1/users/me` | Update own profile |
-| GET | `/api/v1/users/me` | Get own profile |
+| GET | `/api/users` | List all users |
+| GET | `/api/users/search?q=term` | Search users by display name |
+| GET | `/api/users/me` | Get own profile |
+| PUT | `/api/users/me` | Update own profile |
+| GET | `/api/users/{id}` | Get user profile |
 
 #### Admin
 
 | Method | Route | Description |
 |--------|-------|-------------|
-| GET | `/api/v1/admin/settings` | Get server settings |
-| PUT | `/api/v1/admin/settings` | Update server settings |
-| POST | `/api/v1/admin/users` | Create user (closed registration) |
-| PUT | `/api/v1/admin/users/{id}/role` | Assign role to user |
-| POST | `/api/v1/admin/invites` | Generate invite code |
-| DELETE | `/api/v1/admin/invites/{code}` | Revoke invite |
+| GET | `/api/admin/settings` | Get server settings |
+| PUT | `/api/admin/settings` | Update server settings |
+| GET | `/api/admin/users` | List all users (admin view) |
+| POST | `/api/admin/users` | Create user (closed registration) |
+| PUT | `/api/admin/users/{id}/role` | Assign role to user |
+| DELETE | `/api/admin/users/{id}` | Delete user |
+| GET | `/api/admin/invites` | List all invites |
+| POST | `/api/admin/invites` | Generate invite code |
+| DELETE | `/api/admin/invites/{code}` | Revoke invite |
+| PUT | `/api/admin/channels/reorder` | Reorder channels |
+| POST | `/api/admin/apikeys` | Create API key |
+| GET | `/api/admin/apikeys` | List API keys |
+| PUT | `/api/admin/apikeys/{id}/revoke` | Revoke API key |
+
+#### Agents
+
+| Method | Route | Description |
+|--------|-------|-------------|
+| POST | `/api/admin/agents` | Create agent account with API key |
+| GET | `/api/admin/agents` | List agents created by API key |
+
+#### Health
+
+| Method | Route | Description |
+|--------|-------|-------------|
+| GET | `/api/health` | Health check endpoint (database connectivity) |
 
 ### 2.4 SignalR Hub Design
 
@@ -294,18 +336,21 @@ Handles all real-time text messaging, presence, and notification delivery.
 
 | Method | Parameters | Description |
 |--------|-----------|-------------|
-| `ReceiveMessage` | `message: MessageDto` | New channel message |
-| `ReceiveDirectMessage` | `message: DirectMessageDto` | New DM |
-| `UserJoined` | `channelId: Guid, user: UserDto` | User joined channel |
-| `UserLeft` | `channelId: Guid, userId: Guid` | User left channel |
+| `ReceiveMessage` | `message: MessageResponse` | New channel message |
+| `ReceiveDirectMessage` | `message: DirectMessageResponse` | New DM |
+| `UserJoinedChannel` | `channelId: Guid, userId: Guid, displayName: string` | User joined channel |
+| `UserLeftChannel` | `channelId: Guid, userId: Guid` | User left channel |
 | `UserTyping` | `channelId: Guid, userId: Guid` | Typing indicator |
 | `UserStoppedTyping` | `channelId: Guid, userId: Guid` | Stopped typing |
-| `PresenceUpdate` | `userId: Guid, status: UserStatus` | User status changed |
-| `Notification` | `notification: NotificationDto` | General notification |
+| `DirectMessageTyping` | `senderId: Guid` | DM typing indicator |
+| `DirectMessageStoppedTyping` | `senderId: Guid` | DM stopped typing |
+| `UserStatusChanged` | `userId: Guid, displayName: string, status: UserStatus, isAgent: bool` | User status changed |
+| `OnlineUsers` | `users: OnlineUserInfo[]` | Full list of online users (sent on connect) |
+| `ReceiveNotification` | `notification: NotificationDto` | General notification |
 
 **Connection Lifecycle:**
-- `OnConnectedAsync`: Mark user online, notify all connected clients, join user's subscribed channel groups
-- `OnDisconnectedAsync`: Mark user offline (with grace period for reconnection), notify clients, clean up groups
+- `OnConnectedAsync`: Register connection, mark user online, broadcast `UserStatusChanged` to others, send `OnlineUsers` list to caller
+- `OnDisconnectedAsync`: Remove connection, start grace period timer (30s). If no reconnect occurs within grace period, PresenceService raises `OnUserStatusChanged` event which triggers broadcast via IHubContext
 
 **Group Management:**
 - Each text channel maps to a SignalR group named `channel:{channelId}`
@@ -326,6 +371,7 @@ Handles WebRTC signaling only -- no audio passes through the server.
 | `SendIceCandidate` | `targetUserId: Guid, candidate: string` | Send ICE candidate |
 | `ToggleMute` | `channelId: Guid, isMuted: bool` | Broadcast mute status |
 | `ToggleDeafen` | `channelId: Guid, isDeafened: bool` | Broadcast deafen status |
+| `GetIceServers` | (none) | Returns ICE server configuration |
 
 **Client Methods:**
 
@@ -336,9 +382,12 @@ Handles WebRTC signaling only -- no audio passes through the server.
 | `ReceiveOffer` | `fromUserId: Guid, sdp: string` | Receive SDP offer |
 | `ReceiveAnswer` | `fromUserId: Guid, sdp: string` | Receive SDP answer |
 | `ReceiveIceCandidate` | `fromUserId: Guid, candidate: string` | Receive ICE candidate |
-| `UserMuteChanged` | `userId: Guid, isMuted: bool` | Peer mute state |
-| `UserDeafenChanged` | `userId: Guid, isDeafened: bool` | Peer deafen state |
-| `VoiceChannelState` | `users: VoiceUserDto[]` | Full voice channel state on join |
+| `UserMuteChanged` | `channelId: Guid, userId: Guid, isMuted: bool` | Peer mute state (3 params) |
+| `UserDeafenChanged` | `channelId: Guid, userId: Guid, isDeafened: bool` | Peer deafen state (3 params) |
+| `VoiceChannelUsers` | `channelId: Guid, users: VoiceUserDto[]` | Full voice channel state on join |
+
+**Connection Lifecycle:**
+- `OnDisconnectedAsync`: Automatically removes user from all voice channels and notifies peers via `UserLeftVoice`
 
 ---
 
@@ -350,90 +399,77 @@ Handles WebRTC signaling only -- no audio passes through the server.
 HotBox.Client/
 +-- wwwroot/
 |   +-- css/
-|   |   +-- app.css                     # Main styles (from design tokens)
+|   |   +-- app.css                     # Main styles with design tokens
 |   +-- js/
 |   |   +-- webrtc-interop.js           # WebRTC JSInterop bridge
 |   |   +-- notification-interop.js     # Browser notification API bridge
-|   |   +-- audio-interop.js            # Audio device enumeration/control
 |   +-- index.html
 +-- Layout/
-|   +-- MainLayout.razor                # App shell: sidebar + main content
+|   +-- MainLayout.razor                # App shell: top bar + main content + members overlay
 |   +-- MainLayout.razor.css
+|   +-- AuthLayout.razor                # Layout for login/register pages
+|   +-- AdminLayout.razor               # Layout for admin pages
++-- Pages/
+|   +-- IndexRedirect.razor             # Redirect to /channels
+|   +-- LoginPage.razor
+|   +-- RegisterPage.razor
+|   +-- OAuthCallbackPage.razor
+|   +-- ChannelPage.razor               # Channel view
+|   +-- DmsPage.razor                   # DM list view
+|   +-- DirectMessagePage.razor         # DM conversation view
+|   +-- AdminPage.razor                 # Admin dashboard
 +-- Components/
-|   +-- Sidebar/
-|   |   +-- Sidebar.razor               # Left sidebar container
-|   |   +-- ServerHeader.razor
-|   |   +-- ChannelList.razor           # Text + voice channel list
-|   |   +-- ChannelItem.razor
-|   |   +-- VoiceChannelItem.razor
-|   |   +-- VoiceUserList.razor
-|   |   +-- DirectMessageList.razor
-|   |   +-- DirectMessageItem.razor
-|   |   +-- UserPanel.razor             # Bottom-left user info + controls
-|   |   +-- VoiceConnectedPanel.razor   # Voice connection controls
 |   +-- Chat/
-|   |   +-- ChatView.razor              # Main chat area
-|   |   +-- ChannelHeader.razor
+|   |   +-- ChannelList.razor           # Horizontal channel tabs
+|   |   +-- DirectMessageList.razor     # Horizontal DM tabs
+|   |   +-- ChannelHeader.razor         # Channel info bar
 |   |   +-- MessageList.razor           # Scrollable message area
-|   |   +-- MessageGroup.razor          # Grouped messages by author
-|   |   +-- MessageInput.razor          # Text input + send
+|   |   +-- DirectMessageMessageList.razor  # DM message list
+|   |   +-- MessageInput.razor          # Channel message input
+|   |   +-- DirectMessageInput.razor    # DM message input
 |   |   +-- TypingIndicator.razor
-|   +-- Search/
-|   |   +-- SearchOverlay.razor         # Ctrl+K modal overlay
-|   |   +-- SearchOverlay.razor.css
-|   |   +-- SearchInput.razor           # Debounced search input
-|   |   +-- SearchResults.razor         # Scrollable result list
-|   |   +-- SearchResultItem.razor      # Individual result card
-|   |   +-- SearchHighlight.razor       # Query term highlighting
-|   +-- Members/
-|   |   +-- MembersPanel.razor          # Right-side members panel
-|   |   +-- MemberItem.razor
-|   +-- Auth/
-|   |   +-- LoginPage.razor
-|   |   +-- RegisterPage.razor
-|   |   +-- OAuthButtons.razor          # Dynamic OAuth provider buttons
+|   |   +-- MembersPanel.razor          # Right-side slide-in members panel
+|   +-- SearchOverlay.razor             # Ctrl+K modal overlay
+|   +-- ConnectionStatus.razor          # Connection status banner
+|   +-- GlobalErrorBoundary.razor
+|   +-- NewDmPicker.razor               # User picker for new DM
+|   +-- Profile/
+|   |   +-- UserProfilePopover.razor    # Popover for user profile
+|   |   +-- EditProfileModal.razor      # Modal for editing own profile
 |   +-- Admin/
-|   |   +-- AdminPanel.razor
-|   |   +-- ChannelManagement.razor
-|   |   +-- UserManagement.razor
-|   |   +-- InviteManagement.razor
-|   |   +-- ServerSettings.razor
-|   +-- Shared/
-|       +-- Avatar.razor                # Reusable avatar with status dot
-|       +-- StatusDot.razor
-|       +-- UnreadBadge.razor
-|       +-- LoadingSpinner.razor
-|       +-- ErrorBoundary.razor
+|       +-- AdminServerSettings.razor
+|       +-- AdminChannelManagement.razor
+|       +-- AdminUserManagement.razor
+|       +-- AdminInviteManagement.razor
+|       +-- AdminApiKeyManagement.razor
 +-- Services/
-|   +-- IApiClient.cs                   # HTTP API client interface
-|   +-- ApiClient.cs                    # HttpClient wrapper for REST calls
-|   +-- IChatHubService.cs
-|   +-- ChatHubService.cs              # SignalR ChatHub client
-|   +-- IVoiceHubService.cs
-|   +-- VoiceHubService.cs             # SignalR VoiceSignalingHub client
-|   +-- IWebRtcService.cs
-|   +-- WebRtcService.cs               # WebRTC JSInterop wrapper
-|   +-- INotificationService.cs
-|   +-- NotificationService.cs         # Browser notification JSInterop
-|   +-- IAuthService.cs
-|   +-- AuthService.cs                 # Auth state, token management
+|   +-- ApiClient.cs                    # HttpClient wrapper (no interface)
+|   +-- ChatHubService.cs               # SignalR ChatHub client (no interface)
+|   +-- VoiceHubService.cs              # SignalR VoiceSignalingHub client (no interface)
+|   +-- VoiceConnectionManager.cs       # Manages WebRTC peer connections
+|   +-- WebRtcService.cs                # WebRTC JSInterop wrapper (no interface)
+|   +-- NotificationService.cs          # Browser notification JSInterop (no interface)
+|   +-- JwtParser.cs                    # JWT token parsing utility
 +-- State/
-|   +-- AppState.cs                    # Central application state
-|   +-- ChannelState.cs                # Active channel, message cache
-|   +-- VoiceState.cs                  # Voice connection state
-|   +-- PresenceState.cs               # User online/offline/idle status
-|   +-- AuthState.cs                   # Current user, JWT tokens
-|   +-- SearchState.cs                 # Search query, results, loading state
+|   +-- AppState.cs                     # Composite state (references all sub-states)
+|   +-- ChannelState.cs                 # Active channel, message cache
+|   +-- DirectMessageState.cs           # Active DM conversation
+|   +-- VoiceState.cs                   # Voice connection state
+|   +-- PresenceState.cs                # User online/offline/idle status
+|   +-- AuthState.cs                    # Current user, JWT tokens
+|   +-- SearchState.cs                  # Search query, results, loading state
 +-- Models/
-|   +-- ChannelDto.cs
-|   +-- MessageDto.cs
-|   +-- DirectMessageDto.cs
-|   +-- UserDto.cs
-|   +-- VoiceUserDto.cs
-|   +-- NotificationDto.cs
-|   +-- AuthResponseDto.cs
-|   +-- SearchResultDto.cs
-|   +-- SearchResponse.cs
+|   +-- MessageResponse.cs
+|   +-- DirectMessageResponse.cs
+|   +-- ChannelResponse.cs
+|   +-- UserProfileResponse.cs
+|   +-- UserInfo.cs
+|   +-- AuthResponse.cs
+|   +-- OnlineUserInfoModel.cs
+|   +-- VoiceUserInfo.cs
+|   +-- SearchResultModel.cs
+|   +-- SearchResultItemModel.cs
+|   +-- (many other *Response/*Request models)
 +-- Program.cs
 +-- _Imports.razor
 +-- HotBox.Client.csproj
@@ -444,39 +480,55 @@ HotBox.Client/
 ```
 App.razor
 +-- Router
-    +-- MainLayout.razor
-        +-- Sidebar.razor
-        |   +-- ServerHeader.razor
-        |   +-- ChannelList.razor
-        |   |   +-- ChannelItem.razor (foreach text channel)
-        |   |   +-- VoiceChannelItem.razor (foreach voice channel)
-        |   |       +-- VoiceUserList.razor
-        |   +-- DirectMessageList.razor
-        |   |   +-- DirectMessageItem.razor (foreach DM)
-        |   +-- VoiceConnectedPanel.razor (when in voice)
-        |   +-- UserPanel.razor
-        +-- ChatView.razor (or DMView, AdminPanel based on route)
-        |   +-- ChannelHeader.razor
-        |   +-- MessageList.razor
-        |   |   +-- MessageGroup.razor (foreach author group)
-        |   +-- TypingIndicator.razor
-        |   +-- MessageInput.razor
-        +-- MembersPanel.razor (toggleable)
-            +-- MemberItem.razor (foreach member)
+    +-- MainLayout.razor (top-bar layout)
+        +-- ConnectionStatus.razor
+        +-- TopBar
+        |   +-- Brand
+        |   +-- Section Switcher (Channels / DMs)
+        |   +-- ChannelList.razor (horizontal tabs, rendered when "channels" active)
+        |   +-- DirectMessageList.razor (horizontal tabs, rendered when "dms" active)
+        |   +-- Voice Dropdown (voice channels + join button)
+        |   +-- Members Toggle Button
+        |   +-- Search Button (opens SearchOverlay)
+        |   +-- Admin Link (if user is admin)
+        |   +-- User Avatar (with profile popover)
+        +-- Main Content Area (full width)
+        |   +-- ChannelPage.razor (route: /channels/{id})
+        |   |   +-- ChannelHeader.razor
+        |   |   +-- MessageList.razor
+        |   |   +-- TypingIndicator.razor
+        |   |   +-- MessageInput.razor
+        |   +-- DirectMessagePage.razor (route: /dm/{userId})
+        |   |   +-- ChannelHeader.razor
+        |   |   +-- DirectMessageMessageList.razor
+        |   |   +-- TypingIndicator.razor
+        |   |   +-- DirectMessageInput.razor
+        +-- MembersPanel.razor (slide-in overlay from right, toggleable)
+        +-- Bottom Voice Bar (when connected to voice)
+        +-- SearchOverlay.razor (modal, Ctrl+K)
 ```
 
 ### 3.3 State Management
 
-The client uses a service-based state management approach -- no external state library. State services are registered as scoped services (singleton-like in Blazor WASM) and use events to notify components of changes.
+The client uses a service-based state management approach with no external state library. State is split into domain-specific sub-states, each registered as a scoped service (singleton-like in Blazor WASM) and using events to notify components of changes.
+
+**State services:**
+- `AuthState` — Current user, access token (in-memory), login/logout state
+- `ChannelState` — Active channel, message cache, unread counts
+- `DirectMessageState` — Active DM conversation, message cache, conversation summaries
+- `PresenceState` — Online/offline/idle status for all users
+- `VoiceState` — Current voice channel, connected peers, mute/deafen state
+- `SearchState` — Search query, results, loading state
+- `AppState` — Composite state that references all sub-states for convenience
 
 ```csharp
-// Pattern for state services
-public class AppState
+// Pattern used by all state services
+public class ChannelState
 {
     public event Action? OnChange;
 
-    private ChannelDto? _activeChannel;
-    public ChannelDto? ActiveChannel
+    private ChannelResponse? _activeChannel;
+    public ChannelResponse? ActiveChannel
     {
         get => _activeChannel;
         set { _activeChannel = value; NotifyStateChanged(); }
@@ -492,77 +544,128 @@ Components subscribe in `OnInitialized` and unsubscribe in `Dispose`:
 @implements IDisposable
 
 @code {
-    [Inject] private AppState State { get; set; } = default!;
+    [Inject] private ChannelState ChannelState { get; set; } = default!;
 
     protected override void OnInitialized()
     {
-        State.OnChange += StateHasChanged;
+        ChannelState.OnChange += StateHasChanged;
     }
 
     public void Dispose()
     {
-        State.OnChange -= StateHasChanged;
+        ChannelState.OnChange -= StateHasChanged;
     }
 }
 ```
 
 ### 3.4 SignalR Client Integration
 
-Both hub connections are established after login and maintained for the session lifetime. Reconnection is handled automatically with exponential backoff.
+Both hub connections are established after login and maintained for the session lifetime. Reconnection is handled automatically with default exponential backoff (0s, 2s, 10s, 30s intervals).
 
 ```csharp
-// ChatHubService.cs pattern
-public class ChatHubService : IChatHubService, IAsyncDisposable
+// ChatHubService.cs (concrete class, no interface)
+public class ChatHubService : IAsyncDisposable
 {
     private HubConnection? _hubConnection;
-    private readonly NavigationManager _navigation;
-    private readonly AuthState _authState;
+    private readonly string _baseUrl;
+    private readonly ILogger<ChatHubService> _logger;
 
-    public event Action<MessageDto>? OnMessageReceived;
-    public event Action<Guid, UserStatus>? OnPresenceUpdate;
+    public event Action<MessageResponse>? OnMessageReceived;
+    public event Action<Guid, string, string, bool>? OnUserStatusChanged;
+    public event Action<DirectMessageResponse>? OnDirectMessageReceived;
+    // ... more events
 
-    public async Task ConnectAsync()
+    public async Task StartAsync(string accessToken)
     {
         _hubConnection = new HubConnectionBuilder()
-            .WithUrl(_navigation.ToAbsoluteUri("/hubs/chat"), options =>
+            .WithUrl($"{_baseUrl}/hubs/chat", options =>
             {
-                options.AccessTokenProvider = () => Task.FromResult(_authState.AccessToken);
+                options.AccessTokenProvider = () => Task.FromResult<string?>(accessToken);
             })
-            .WithAutomaticReconnect(new[] { TimeSpan.Zero, TimeSpan.FromSeconds(2),
-                TimeSpan.FromSeconds(5), TimeSpan.FromSeconds(10) })
+            .WithAutomaticReconnect()  // Uses default intervals
             .Build();
 
-        _hubConnection.On<MessageDto>("ReceiveMessage", message =>
+        RegisterHandlers(_hubConnection);
+        RegisterLifecycleEvents(_hubConnection);
+
+        await _hubConnection.StartAsync();
+        _logger.LogInformation("ChatHub connection started");
+    }
+
+    private void RegisterHandlers(HubConnection connection)
+    {
+        connection.On<MessageResponse>("ReceiveMessage", message =>
         {
             OnMessageReceived?.Invoke(message);
         });
 
-        await _hubConnection.StartAsync();
+        connection.On<Guid, string, string, bool>("UserStatusChanged", (userId, displayName, status, isAgent) =>
+        {
+            OnUserStatusChanged?.Invoke(userId, displayName, status, isAgent);
+        });
+
+        // ... other handlers
     }
 }
 ```
 
 ### 3.5 Design Tokens
 
-The UI design system is defined in the existing HTML prototype at `c:\Users\cpike\workspace\hot-box\temp\prototype.html`. The CSS custom properties (design tokens) from that prototype will be carried into the Blazor app's `wwwroot/css/app.css`. Key tokens include:
+The UI design system is defined in `wwwroot/css/app.css` using CSS custom properties. Key tokens include:
 
 | Token | Value | Usage |
 |-------|-------|-------|
-| `--bg-deepest` | `#1a1a1e` | Outermost background, user panel |
-| `--bg-deep` | `#1e1e23` | Sidebar, members panel |
-| `--bg-base` | `#232329` | Main content area |
-| `--bg-raised` | `#2a2a32` | Message input, cards |
-| `--bg-surface` | `#32323c` | Avatars, elevated surfaces |
-| `--bg-hover` | `#3a3a46` | Hover states |
-| `--bg-active` | `#424250` | Active/selected states |
-| `--text-primary` | `#e4e4e8` | Primary text |
-| `--text-secondary` | `#a0a0aa` | Secondary text, message bodies |
-| `--text-muted` | `#6e6e7a` | Timestamps, hints |
-| `--accent` | `#7aa2f7` | Links, active indicators, accent color |
-| `--status-online` | `#50c878` | Online status dot |
-| `--status-idle` | `#e2b93d` | Idle status dot |
-| `--status-dnd` | `#f7768e` | Do Not Disturb status dot |
-| `--status-offline` | `#565664` | Offline status dot |
+| **Background layers** | | Deep cool slate palette |
+| `--bg-deepest` | `#0c0c0f` | Outermost background |
+| `--bg-deep` | `#111116` | Top bar background |
+| `--bg-base` | `#16161d` | Main content area |
+| `--bg-raised` | `#1c1c25` | Message input, cards |
+| `--bg-surface` | `#23232e` | Avatars, elevated surfaces |
+| `--bg-hover` | `#2a2a37` | Hover states |
+| `--bg-active` | `#32323f` | Active/selected states |
+| **Text** | | |
+| `--text-primary` | `#e2e2ea` | Primary text |
+| `--text-secondary` | `#9898a8` | Secondary text, message bodies |
+| `--text-muted` | `#5c5c72` | Timestamps, hints |
+| `--text-faint` | `#3e3e52` | Very subtle text |
+| **Accent** | | Cool teal/mint |
+| `--accent` | `#5de4c7` | Links, active indicators, primary accent |
+| `--accent-hover` | `#7aecd5` | Hover state |
+| `--accent-muted` | `rgba(93, 228, 199, 0.10)` | Subtle background tint |
+| `--accent-strong` | `#a0f0de` | Strong emphasis |
+| `--accent-glow` | `rgba(93, 228, 199, 0.06)` | Glow/aura effect |
+| **Status** | | User presence indicators |
+| `--status-online` | `#6bc76b` | Online status dot |
+| `--status-idle` | `#c7a63e` | Idle status dot |
+| `--status-dnd` | `#c76060` | Do Not Disturb status dot |
+| `--status-offline` | `#4a4a5a` | Offline status dot |
+| **Voice** | | |
+| `--voice-active` | `#6bc76b` | Voice connected/speaking |
+| `--voice-muted` | `#5c5c72` | Voice muted |
+| **Bot Badge** | | |
+| `--bot-badge-bg` | `rgba(93, 228, 199, 0.12)` | Bot badge background |
+| `--bot-badge-color` | `var(--accent)` | Bot badge text |
+| **Borders** | | |
+| `--border-subtle` | `rgba(255, 255, 255, 0.04)` | Very subtle border |
+| `--border-light` | `rgba(255, 255, 255, 0.07)` | Light border |
+| `--border-focus` | `rgba(93, 228, 199, 0.3)` | Focus ring |
+| **Radius** | | |
+| `--radius-xs` | `3px` | Very small radius |
+| `--radius-sm` | `4px` | Small radius |
+| `--radius-md` | `8px` | Medium radius |
+| `--radius-lg` | `12px` | Large radius |
+| `--radius-pill` | `9999px` | Pill shape |
+| **Shadows** | | |
+| `--shadow-md` | `0 4px 24px rgba(0, 0, 0, 0.5)` | Medium shadow |
+| `--shadow-lg` | `0 8px 48px rgba(0, 0, 0, 0.6)` | Large shadow |
+| `--shadow-overlay` | `0 12px 40px rgba(0, 0, 0, 0.7), 0 0 0 1px var(--border-subtle)` | Overlay shadow |
+| **Transitions** | | |
+| `--transition-fast` | `100ms ease` | Fast transition |
+| `--transition-base` | `180ms ease` | Base transition |
+| `--transition-smooth` | `280ms cubic-bezier(0.4, 0, 0.2, 1)` | Smooth transition |
+| **Typography** | | |
+| `--font-body` | `'DM Sans', -apple-system, BlinkMacSystemFont, sans-serif` | Body font |
+| `--font-mono` | `'JetBrains Mono', 'SF Mono', 'Consolas', monospace` | Monospace font |
 
 ---
 
@@ -576,7 +679,13 @@ The UI design system is defined in the existing HTML prototype at `c:\Users\cpik
 AppUser (inherits IdentityUser<Guid>)
 ├── DisplayName          : string (required, max 32)
 ├── AvatarUrl            : string? (nullable, future use)
+├── Bio                  : string? (nullable, max 500)
+├── Pronouns             : string? (nullable, max 50)
+├── CustomStatus         : string? (nullable, max 100)
 ├── Status               : UserStatus (enum: Online, Idle, DnD, Offline)
+├── IsAgent              : bool (default false, marks bot accounts)
+├── CreatedByApiKeyId    : Guid? (nullable FK -> ApiKey)
+├── CreatedByApiKey      : ApiKey? (navigation property)
 ├── LastSeenUtc          : DateTime
 ├── CreatedAtUtc         : DateTime
 ├── Messages             : ICollection<Message>
@@ -645,6 +754,45 @@ Invite
 ├── MaxUses              : int? (nullable)
 ├── UseCount             : int (default 0)
 ├── IsRevoked            : bool (default false)
+```
+
+#### ApiKey
+
+```
+ApiKey
+├── Id                   : Guid (PK)
+├── KeyValue             : string (SHA-256 hash of actual key)
+├── KeyPrefix            : string (first 8 chars of key, for lookup)
+├── Name                 : string (user-friendly label)
+├── CreatedAtUtc         : DateTime
+├── RevokedAtUtc         : DateTime? (nullable)
+├── RevokedReason        : string? (nullable)
+├── IsRevoked            : bool (computed property)
+├── IsActive             : bool (computed property)
+├── CreatedAgents        : ICollection<AppUser>
+```
+
+#### RefreshToken
+
+```
+RefreshToken
+├── Id                   : Guid (PK)
+├── Token                : string (unique, hashed)
+├── UserId               : Guid (FK -> AppUser)
+├── ExpiresAtUtc         : DateTime
+├── CreatedAtUtc         : DateTime
+├── RevokedAtUtc         : DateTime? (nullable)
+├── ReplacedByToken      : string? (nullable, for rotation tracking)
+├── IsRevoked            : bool (computed property)
+```
+
+#### ServerSettings
+
+```
+ServerSettings
+├── Id                   : Guid (PK, singleton table)
+├── ServerName           : string (max 100)
+├── RegistrationMode     : RegistrationMode (enum)
 ```
 
 ### 4.2 Entity Relationships
@@ -732,7 +880,7 @@ public static IServiceCollection AddHotBoxInfrastructure(
 ### 5.1 ASP.NET Identity Setup
 
 - Identity is configured with `AppUser` (extends `IdentityUser<Guid>`) and `IdentityRole<Guid>`
-- Password requirements: minimum 8 characters, at least one uppercase, one lowercase, one digit
+- Password requirements: minimum 8 characters, at least one uppercase, one lowercase, one digit, `RequireNonAlphanumeric = false`, `RequiredUniqueChars = 4`
 - Account lockout: 5 failed attempts, 15-minute lockout
 - Email confirmation: disabled for MVP (self-hosted, trusted users)
 
@@ -814,16 +962,48 @@ On first run (when no admin user exists), the server creates an admin account fr
 
 ```json
 {
-  "Auth": {
-    "Seed": {
-      "AdminEmail": "admin@hotbox.local",
-      "AdminPassword": "ChangeMe123!"
-    }
+  "AdminSeed": {
+    "Email": "admin@hotbox.local",
+    "Password": "ChangeMe123!",
+    "DisplayName": "Admin"
   }
 }
 ```
 
-This is handled in `Program.cs` during application startup, after `EnsureCreated`/migration.
+This is handled by the `DatabaseSeeder` hosted service, which runs after EF migrations during application startup.
+
+### 5.7 API Key Authentication
+
+API keys enable programmatic access for agent accounts (bots, integrations) without requiring password-based login.
+
+#### Architecture
+
+- Custom authentication handler: `ApiKeyAuthenticationHandler` (registered as `"ApiKey"` scheme)
+- Header-based authentication: `X-Api-Key: hb_xxxxxxxxxxxxx`
+- SHA-256 hashing with prefix-based lookup for performance
+- Dual authentication policy: `JwtOrApiKey` policy accepts either JWT bearer tokens or API keys
+
+#### API Key Format
+
+- Generated key: `hb_{32-char-random-base62}` (e.g., `hb_A1b2C3d4E5f6G7h8I9j0K1l2M3n4O5p6`)
+- Prefix (`hb_`) stored separately for fast lookup
+- Full key is SHA-256 hashed before storage
+
+#### Flow
+
+1. Admin creates API key via `POST /api/admin/apikeys` with a friendly name
+2. Server generates random key, stores hash + prefix, returns full key **once** (never shown again)
+3. Agent uses API key to create bot account via `POST /api/admin/agents`
+4. Bot account includes `IsAgent = true` flag and reference to creating API key
+5. Bot sends messages via REST API or SignalR using `X-Api-Key` header
+6. API keys can be revoked via `PUT /api/admin/apikeys/{id}/revoke`
+
+#### Security Considerations
+
+- API keys bypass password rotation and 2FA (intentional for service accounts)
+- Keys are scoped to admin-level permissions (for agent creation only)
+- Revocation is immediate and enforced at authentication handler level
+- LastUsedAtUtc tracking for audit purposes
 
 ---
 
@@ -994,56 +1174,58 @@ The `ISearchService` interface (defined in Core) abstracts the provider differen
 // HotBox.Core/Interfaces/ISearchService.cs
 public interface ISearchService
 {
-    Task<SearchResult> SearchMessagesAsync(
-        Guid callingUserId,
-        string query,
-        Guid? channelId = null,
-        Guid? authorId = null,
-        DateTime? before = null,
-        DateTime? after = null,
-        int page = 1,
-        int pageSize = 25,
-        CancellationToken cancellationToken = default);
+    Task<SearchResult> SearchMessagesAsync(SearchQuery query, CancellationToken ct = default);
 
-    Task<SearchResult> SearchDirectMessagesAsync(
-        Guid callingUserId,
-        string query,
-        Guid? participantId = null,
-        DateTime? before = null,
-        DateTime? after = null,
-        int page = 1,
-        int pageSize = 25,
-        CancellationToken cancellationToken = default);
+    Task InitializeIndexAsync(CancellationToken ct = default);
 
-    Task EnsureSearchIndexAsync(CancellationToken cancellationToken = default);
+    Task ReindexAsync(CancellationToken ct = default);
+
+    bool IsFullTextSearchAvailable { get; }
+
+    string ProviderName { get; }
 }
 ```
 
-#### Search Result Shape
+#### Search Query and Result Models
 
 ```csharp
-public class SearchResult
+// HotBox.Core/Models/SearchQuery.cs
+public class SearchQuery
 {
-    public IReadOnlyList<SearchHit> Items { get; init; } = [];
-    public long TotalCount { get; init; }
-    public int Page { get; init; }
-    public int PageSize { get; init; }
-    public bool IsDegraded { get; init; } // True if using LIKE fallback
+    public string QueryText { get; set; } = string.Empty;
+    public Guid? ChannelId { get; set; }
+    public Guid? SenderId { get; set; }
+    public string? Cursor { get; set; }  // Opaque cursor for pagination
+    public int Limit { get; set; } = 20;
 }
 
-public class SearchHit
+// HotBox.Core/Models/SearchResult.cs
+public class SearchResult
 {
-    public Guid MessageId { get; init; }
-    public string Content { get; init; } = string.Empty;
-    public string ContentHighlight { get; init; } = string.Empty; // Snippet with <mark> tags
-    public Guid ChannelId { get; init; }    // For channel messages
-    public string ChannelName { get; init; } = string.Empty;
-    public Guid AuthorId { get; init; }
-    public string AuthorDisplayName { get; init; } = string.Empty;
-    public DateTime CreatedAtUtc { get; init; }
-    public double Score { get; init; }
+    public IReadOnlyList<SearchResultItem> Items { get; set; } = [];
+    public string? Cursor { get; set; }  // Opaque cursor for next page
+    public int TotalEstimate { get; set; }  // Estimated total (not exact count)
+}
+
+// HotBox.Core/Models/SearchResultItem.cs
+public class SearchResultItem
+{
+    public Guid MessageId { get; set; }
+    public string Snippet { get; set; } = string.Empty;  // Snippet with highlighting
+    public Guid ChannelId { get; set; }
+    public string ChannelName { get; set; } = string.Empty;
+    public Guid AuthorId { get; set; }
+    public string AuthorDisplayName { get; set; } = string.Empty;
+    public DateTime CreatedAtUtc { get; set; }
+    public double RelevanceScore { get; set; }
 }
 ```
+
+**Key changes from offset pagination:**
+- Uses opaque cursor-based pagination instead of page/pageSize
+- `TotalEstimate` instead of `TotalCount` (exact counts are expensive for FTS)
+- `Snippet` field contains highlighted text (implementation-dependent format)
+- `RelevanceScore` instead of `Score` for clarity
 
 #### Implementation Details
 
@@ -1058,17 +1240,17 @@ public class SearchHit
 #### Search Scope and Permissions
 
 - **Channel messages**: All authenticated users can search all channels (no per-channel permissions in MVP). `channelId` parameter optionally scopes to a single channel.
-- **Direct messages**: Queries are always filtered to conversations involving the calling user (`senderId == callingUserId OR recipientId == callingUserId`). This is enforced at the service level.
-- **Offset pagination**: Search results are relevance-ranked, not time-ordered, so cursor-based pagination does not apply. Standard page/pageSize is used.
+- **Direct messages**: Not implemented in MVP. Future implementation would filter to conversations involving the calling user.
+- **Cursor-based pagination**: Search results use cursor-based pagination for efficiency. The cursor is an opaque string (implementation-specific) that encodes the pagination state.
 
 #### Index Initialization
 
-On application startup, `EnsureSearchIndexAsync` is called to create FTS infrastructure if it does not exist:
+On application startup (in `Program.cs`), `InitializeIndexAsync` is called to create FTS infrastructure if it does not exist:
 - PostgreSQL: Creates `SearchVector` column, GIN index, and update trigger
 - MySQL/MariaDB: Creates `FULLTEXT` index
 - SQLite: Creates FTS5 virtual table and sync triggers
 
-For existing instances with messages, the admin endpoint `POST /api/v1/admin/search/reindex` rebuilds the search index by batch-processing all existing messages.
+For existing instances with messages, the admin endpoint `POST /api/search/reindex` rebuilds the search index by batch-processing all existing messages.
 
 ---
 
@@ -1078,9 +1260,10 @@ For existing instances with messages, the admin endpoint `POST /api/v1/admin/sea
 
 ```json
 {
-  "HotBox": {
-    "ServerName": "The HotBox",
-    "Port": 5000
+  "Server": {
+    "ServerName": "HotBox",
+    "Port": 5000,
+    "RegistrationMode": "InviteOnly"
   },
 
   "Database": {
@@ -1088,96 +1271,78 @@ For existing instances with messages, the admin endpoint `POST /api/v1/admin/sea
     "ConnectionString": "Data Source=hotbox.db"
   },
 
-  "Auth": {
-    "RegistrationMode": "Open",
-    "Seed": {
-      "AdminEmail": "admin@hotbox.local",
-      "AdminPassword": "ChangeMe123!",
-      "AdminDisplayName": "Admin"
+  "Jwt": {
+    "Secret": "",
+    "Issuer": "HotBox",
+    "Audience": "HotBox",
+    "AccessTokenExpiration": "00:15:00",
+    "RefreshTokenExpiration": "7.00:00:00"
+  },
+
+  "OAuth": {
+    "Google": {
+      "ClientId": "",
+      "ClientSecret": "",
+      "Enabled": false
     },
-    "Jwt": {
-      "Secret": "CHANGE-THIS-TO-A-RANDOM-64-CHAR-STRING",
-      "Issuer": "HotBox",
-      "Audience": "HotBox",
-      "AccessTokenExpirationMinutes": 15,
-      "RefreshTokenExpirationDays": 7
-    },
-    "OAuth": {
-      "Google": {
-        "Enabled": false,
-        "ClientId": "",
-        "ClientSecret": ""
-      },
-      "Microsoft": {
-        "Enabled": false,
-        "ClientId": "",
-        "ClientSecret": ""
-      }
+    "Microsoft": {
+      "ClientId": "",
+      "ClientSecret": "",
+      "Enabled": false
     }
   },
 
-  "Search": {
-    "Enabled": true,
-    "DefaultPageSize": 25,
-    "MaxPageSize": 100,
-    "MinQueryLength": 2
-  },
-
-  "Voice": {
-    "IceServers": [
-      {
-        "Urls": ["stun:stun.l.google.com:19302"]
-      }
-    ]
+  "IceServers": {
+    "StunUrls": [
+      "stun:stun.l.google.com:19302"
+    ],
+    "TurnUrl": "",
+    "TurnUsername": "",
+    "TurnCredential": ""
   },
 
   "Observability": {
-    "Serilog": {
-      "MinimumLevel": "Information",
-      "Seq": {
-        "Enabled": true,
-        "ServerUrl": "http://localhost:5341"
-      },
-      "Elasticsearch": {
-        "Enabled": false,
-        "NodeUrls": ["http://localhost:9200"]
-      }
-    },
-    "OpenTelemetry": {
-      "Enabled": true,
-      "Endpoint": "http://localhost:4317",
-      "ServiceName": "HotBox"
-    }
+    "SeqUrl": "http://localhost:5341",
+    "OtlpEndpoint": "",
+    "LogLevel": "Information"
   },
 
-  "Channels": {
-    "DefaultChannels": [
-      { "Name": "general", "Topic": "General conversation", "Type": "Text" },
-      { "Name": "Lounge", "Topic": null, "Type": "Voice" }
-    ]
-  },
-
-  "Roles": {
-    "Definitions": ["Admin", "Moderator", "Member"],
-    "DefaultRole": "Member"
+  "AdminSeed": {
+    "Email": "",
+    "Password": "",
+    "DisplayName": ""
   }
 }
 ```
 
+**Key differences from the original spec:**
+- Top-level section is `Server` (not `HotBox`)
+- `RegistrationMode` is in `Server` (not `Auth`)
+- JWT section is top-level (not `Auth.Jwt`)
+- OAuth section is top-level (not `Auth.OAuth`)
+- `IceServers` is a flat object with arrays, not nested `Voice.IceServers`
+- `Observability` is flat (no nested `Serilog`/`OpenTelemetry` sections)
+- `AdminSeed` is top-level (not `Auth.Seed`)
+- JWT expiration uses TimeSpan format (`"00:15:00"`) not integer minutes
+- No `Search` section (search is always enabled)
+- No `Channels` or `Roles` sections (seeded by DatabaseSeeder)
+
 ### 8.2 Options Pattern Classes
 
-Each configuration section maps to a strongly-typed Options class:
+Each configuration section maps to a strongly-typed Options class (all located in `HotBox.Core/Options/`):
 
-| Options Class | Config Section | Registration |
-|---------------|---------------|-------------|
-| `HotBoxOptions` | `HotBox` | `services.Configure<HotBoxOptions>(config.GetSection("HotBox"))` |
-| `DatabaseOptions` | `Database` | `services.Configure<DatabaseOptions>(config.GetSection("Database"))` |
-| `AuthOptions` | `Auth` | `services.Configure<AuthOptions>(config.GetSection("Auth"))` |
-| `OAuthProviderOptions` | `Auth:OAuth:{Provider}` | Bound per provider |
-| `JwtOptions` | `Auth:Jwt` | `services.Configure<JwtOptions>(config.GetSection("Auth:Jwt"))` |
-| `SearchOptions` | `Search` | `services.Configure<SearchOptions>(config.GetSection("Search"))` |
-| `VoiceOptions` | `Voice` | `services.Configure<VoiceOptions>(config.GetSection("Voice"))` |
-| `ObservabilityOptions` | `Observability` | `services.Configure<ObservabilityOptions>(config.GetSection("Observability"))` |
+| Options Class | Config Section | Location |
+|---------------|---------------|----------|
+| `ServerOptions` | `Server` | `HotBox.Core/Options/` |
+| `DatabaseOptions` | `Database` | `HotBox.Core/Options/` |
+| `JwtOptions` | `Jwt` | `HotBox.Core/Options/` |
+| `OAuthOptions` | `OAuth` | `HotBox.Core/Options/` |
+| `IceServerOptions` | `IceServers` | `HotBox.Core/Options/` |
+| `ObservabilityOptions` | `Observability` | `HotBox.Core/Options/` |
+| `AdminSeedOptions` | `AdminSeed` | `HotBox.Core/Options/` |
+| `SearchOptions` | (internal defaults) | `HotBox.Core/Options/` |
+
+**Note:** All Options classes are in the Core project (not Application) to avoid circular dependencies and allow Infrastructure services to access configuration.
 
 ### 8.3 Environment Variable Overrides
 
@@ -1186,11 +1351,13 @@ All settings can be overridden via environment variables using the standard ASP.
 ```
 Database__Provider=postgresql
 Database__ConnectionString=Host=db;Database=hotbox;Username=hotbox;Password=secret
-Auth__RegistrationMode=InviteOnly
-Auth__Jwt__Secret=my-production-secret-key-at-least-64-chars
-Auth__OAuth__Google__Enabled=true
-Auth__OAuth__Google__ClientId=xxx.apps.googleusercontent.com
-Auth__OAuth__Google__ClientSecret=xxx
+Server__RegistrationMode=InviteOnly
+Jwt__Secret=my-production-secret-key-at-least-64-chars
+OAuth__Google__Enabled=true
+OAuth__Google__ClientId=xxx.apps.googleusercontent.com
+OAuth__Google__ClientSecret=xxx
+AdminSeed__Email=admin@example.com
+AdminSeed__Password=SecurePassword123
 ```
 
 ---
@@ -1201,54 +1368,57 @@ Auth__OAuth__Google__ClientSecret=xxx
 
 **NuGet Packages:**
 - `Serilog.AspNetCore` -- ASP.NET Core integration
-- `Serilog.Sinks.Console` -- Console output
-- `Serilog.Sinks.Seq` -- Seq log aggregation (development)
-- `Elastic.Serilog.Sinks` -- Elasticsearch (production) -- the modern replacement for the archived `Serilog.Sinks.Elasticsearch`
-- `Serilog.Sinks.Async` -- Async wrapper for production sinks
-- `Serilog.Enrichers.Environment` -- Machine name, environment enrichment
-- `Serilog.Exceptions` -- Structured exception detail
+- `Serilog.Sinks.Console` (included with AspNetCore) -- Console output
+- `Serilog.Sinks.Seq` -- Seq log aggregation
+- `Serilog.Sinks.Elasticsearch` -- Elasticsearch sink (archived but still functional)
+- `Serilog.Enrichers.Environment` -- Machine name enrichment
+- `Serilog.Enrichers.Thread` -- Thread ID enrichment
 
 **Configuration in `ObservabilityExtensions.cs`:**
 
 ```csharp
-public static IServiceCollection AddHotBoxObservability(
-    this IServiceCollection services,
-    IConfiguration configuration,
-    IHostEnvironment environment)
+public static IHostBuilder AddObservability(
+    this IHostBuilder hostBuilder,
+    IConfiguration configuration)
 {
-    // Serilog
-    Log.Logger = new LoggerConfiguration()
-        .ReadFrom.Configuration(configuration)
-        .Enrich.FromLogContext()
-        .Enrich.WithEnvironmentName()
-        .Enrich.WithMachineName()
-        .Enrich.WithExceptionDetails()
-        .WriteTo.Console()
-        .WriteTo.Conditional(
-            _ => configuration.GetValue<bool>("Observability:Serilog:Seq:Enabled"),
-            wt => wt.Seq(configuration["Observability:Serilog:Seq:ServerUrl"]!))
-        .WriteTo.Conditional(
-            _ => configuration.GetValue<bool>("Observability:Serilog:Elasticsearch:Enabled"),
-            wt => wt.Elasticsearch(/* Elastic.Serilog.Sinks config */))
-        .CreateLogger();
+    hostBuilder.UseSerilog((context, services, loggerConfig) =>
+    {
+        var obsOptions = configuration
+            .GetSection(ObservabilityOptions.SectionName)
+            .Get<ObservabilityOptions>() ?? new ObservabilityOptions();
 
-    // OpenTelemetry
-    services.AddOpenTelemetry()
-        .WithTracing(tracing => tracing
-            .AddAspNetCoreInstrumentation()
-            .AddHttpClientInstrumentation()
-            .AddEntityFrameworkCoreInstrumentation()
-            .AddOtlpExporter(o => o.Endpoint = new Uri(
-                configuration["Observability:OpenTelemetry:Endpoint"]!)))
-        .WithMetrics(metrics => metrics
-            .AddAspNetCoreInstrumentation()
-            .AddHttpClientInstrumentation()
-            .AddOtlpExporter(o => o.Endpoint = new Uri(
-                configuration["Observability:OpenTelemetry:Endpoint"]!)));
+        // Parse minimum log level from config with safe fallback
+        if (!Enum.TryParse<Serilog.Events.LogEventLevel>(obsOptions.LogLevel, ignoreCase: true, out var minLevel))
+        {
+            minLevel = Serilog.Events.LogEventLevel.Information;
+        }
 
-    return services;
+        loggerConfig
+            .MinimumLevel.Is(minLevel)
+            .MinimumLevel.Override("Microsoft", Serilog.Events.LogEventLevel.Warning)
+            .MinimumLevel.Override("Microsoft.EntityFrameworkCore", Serilog.Events.LogEventLevel.Warning)
+            .Enrich.FromLogContext()
+            .Enrich.WithMachineName()
+            .Enrich.WithThreadId()
+            .WriteTo.Console();
+
+        // Seq sink (if URL configured)
+        if (!string.IsNullOrWhiteSpace(obsOptions.SeqUrl))
+        {
+            loggerConfig.WriteTo.Seq(obsOptions.SeqUrl);
+        }
+    });
+
+    return hostBuilder;
 }
 ```
+
+**Key differences from original spec:**
+- Uses `Serilog.Sinks.Elasticsearch` (archived package), NOT `Elastic.Serilog.Sinks`
+- Console + Seq only (no conditional Elasticsearch in current implementation)
+- Uses `Enrich.WithThreadId()` not `Enrich.WithExceptionDetails()`
+- Does NOT include `Serilog.Exceptions` or `Serilog.Sinks.Async`
+- Includes `Serilog.Enrichers.Thread` (not originally documented)
 
 ### 9.2 OpenTelemetry Setup
 
@@ -1284,101 +1454,127 @@ public static IServiceCollection AddHotBoxObservability(
 
 ```dockerfile
 # Stage 1: Build
-FROM mcr.microsoft.com/dotnet/sdk:9.0 AS build
+FROM mcr.microsoft.com/dotnet/sdk:8.0 AS build
 WORKDIR /src
 
-COPY *.sln .
-COPY src/HotBox.Core/*.csproj src/HotBox.Core/
-COPY src/HotBox.Infrastructure/*.csproj src/HotBox.Infrastructure/
-COPY src/HotBox.Application/*.csproj src/HotBox.Application/
-COPY src/HotBox.Client/*.csproj src/HotBox.Client/
-RUN dotnet restore
+# Copy solution and project files first for layer caching
+COPY HotBox.sln ./
+COPY src/HotBox.Core/HotBox.Core.csproj src/HotBox.Core/
+COPY src/HotBox.Infrastructure/HotBox.Infrastructure.csproj src/HotBox.Infrastructure/
+COPY src/HotBox.Application/HotBox.Application.csproj src/HotBox.Application/
+COPY src/HotBox.Client/HotBox.Client.csproj src/HotBox.Client/
 
+# Restore dependencies (app only, skip test projects)
+RUN dotnet restore src/HotBox.Application/HotBox.Application.csproj
+
+# Copy everything else and build
 COPY src/ src/
 RUN dotnet publish src/HotBox.Application/HotBox.Application.csproj \
-    -c Release -o /app/publish --no-restore
+    -c Release \
+    -o /app/publish
 
 # Stage 2: Runtime
-FROM mcr.microsoft.com/dotnet/aspnet:9.0 AS runtime
+FROM mcr.microsoft.com/dotnet/aspnet:8.0 AS runtime
 WORKDIR /app
+
+# Install curl for health checks
+RUN apt-get update && apt-get install -y --no-install-recommends curl \
+    && rm -rf /var/lib/apt/lists/*
+
+# Create non-root user
+RUN adduser --disabled-password --gecos '' hotbox \
+    && mkdir -p /data \
+    && chown hotbox:hotbox /data
+USER hotbox
 
 COPY --from=build /app/publish .
 
-ENV ASPNETCORE_URLS=http://+:5000
-EXPOSE 5000
+ENV ASPNETCORE_URLS=http://+:8080
+EXPOSE 8080
 
 ENTRYPOINT ["dotnet", "HotBox.Application.dll"]
 ```
 
-### 10.2 docker-compose.yml (Production)
+**Key differences:**
+- Uses .NET 8.0 (not 9.0)
+- Exposes port 8080 (not 5000)
+- Installs `curl` for health checks
+- Creates non-root `hotbox` user and switches to it
+- Creates `/data` directory for SQLite database persistence
+
+### 10.2 docker-compose.yml
 
 ```yaml
 services:
   hotbox:
     build: .
+    container_name: hotbox
+    restart: unless-stopped
     ports:
-      - "5000:5000"
+      - "8080:8080"
     environment:
+      - ASPNETCORE_ENVIRONMENT=Production
       - Database__Provider=postgresql
-      - Database__ConnectionString=Host=db;Database=hotbox;Username=hotbox;Password=${DB_PASSWORD}
-      - Auth__Jwt__Secret=${JWT_SECRET}
-      - Auth__RegistrationMode=InviteOnly
-      - Observability__Serilog__Elasticsearch__Enabled=true
-      - Observability__Serilog__Elasticsearch__NodeUrls__0=http://elasticsearch:9200
-      - Observability__OpenTelemetry__Endpoint=http://elasticsearch:4317
+      - Database__ConnectionString=Host=db;Port=5432;Database=hotbox;Username=hotbox;Password=${DB_PASSWORD:-changeme}
+      - Jwt__Secret=${JWT_SECRET:-super-secret-key-change-in-production-minimum-32-chars}
+      - Observability__SeqUrl=http://seq:5341
+      - AdminSeed__Email=${ADMIN_EMAIL:-admin@hotbox.local}
+      - AdminSeed__Password=${ADMIN_PASSWORD:-Admin123!}
+      - AdminSeed__DisplayName=${ADMIN_DISPLAY_NAME:-Admin}
     depends_on:
       db:
         condition: service_healthy
-    restart: unless-stopped
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://localhost:8080/health"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+      start_period: 30s
 
   db:
-    image: postgres:17
+    image: postgres:16-alpine
+    container_name: hotbox-db
+    restart: unless-stopped
     environment:
-      - POSTGRES_DB=hotbox
-      - POSTGRES_USER=hotbox
-      - POSTGRES_PASSWORD=${DB_PASSWORD}
+      POSTGRES_DB: hotbox
+      POSTGRES_USER: hotbox
+      POSTGRES_PASSWORD: ${DB_PASSWORD:-changeme}
     volumes:
       - pgdata:/var/lib/postgresql/data
     healthcheck:
       test: ["CMD-SHELL", "pg_isready -U hotbox"]
       interval: 5s
-      timeout: 5s
+      timeout: 3s
       retries: 5
-    restart: unless-stopped
 
-  elasticsearch:
-    image: docker.elastic.co/elasticsearch/elasticsearch:8.17.0
-    environment:
-      - discovery.type=single-node
-      - xpack.security.enabled=false
-      - "ES_JAVA_OPTS=-Xms512m -Xmx512m"
-    volumes:
-      - esdata:/usr/share/elasticsearch/data
+  seq:
+    image: datalust/seq:latest
+    container_name: hotbox-seq
     restart: unless-stopped
+    environment:
+      ACCEPT_EULA: "Y"
+    ports:
+      - "5342:80"
+    volumes:
+      - seqdata:/data
 
 volumes:
   pgdata:
-  esdata:
+  seqdata:
 ```
 
-### 10.3 docker-compose.dev.yml (Development)
+**Key differences:**
+- Single `docker-compose.yml` at repo root (no separate dev file)
+- Uses PostgreSQL 16-alpine (not 17)
+- Exposes port 8080 (not 5000)
+- Includes Seq service (port 5342:80) — NOT Elasticsearch
+- Healthcheck uses `/health` endpoint
+- Environment variables have sensible defaults with `:-` syntax
+- Docker files at repo root, NOT in `docker/` directory
 
-```yaml
-services:
-  seq:
-    image: datalust/seq:latest
-    ports:
-      - "5341:80"
-    environment:
-      - ACCEPT_EULA=Y
-    restart: unless-stopped
-```
+### 10.3 Optional: TURN Server
 
-Development uses SQLite (file-based, no container needed) and Seq for log aggregation.
-
-### 10.4 Optional: TURN Server
-
-For users behind restrictive NATs, a `coturn` container can be added:
+For users behind restrictive NATs, a `coturn` container can be added to `docker-compose.yml`:
 
 ```yaml
   coturn:
@@ -1395,43 +1591,59 @@ For users behind restrictive NATs, a `coturn` container can be added:
     restart: unless-stopped
 ```
 
+Then update the `IceServers` configuration in `appsettings.json`:
+```json
+"IceServers": {
+  "StunUrls": ["stun:stun.l.google.com:19302"],
+  "TurnUrl": "turn:localhost:3478",
+  "TurnUsername": "hotbox",
+  "TurnCredential": "changeme"
+}
+```
+
 ---
 
 ## 11. NuGet Package Summary
 
 ### HotBox.Core
 ```
-(no external packages -- pure domain)
+Microsoft.Extensions.Identity.Stores
 ```
 
 ### HotBox.Infrastructure
 ```
+Microsoft.EntityFrameworkCore
 Microsoft.AspNetCore.Identity.EntityFrameworkCore
 Microsoft.EntityFrameworkCore.Sqlite
+Microsoft.Extensions.Configuration.Binder
+System.IdentityModel.Tokens.Jwt
 Npgsql.EntityFrameworkCore.PostgreSQL
 Pomelo.EntityFrameworkCore.MySql
-Microsoft.EntityFrameworkCore.Tools  (dev dependency)
 ```
 
 ### HotBox.Application
 ```
-Microsoft.AspNetCore.SignalR
-Microsoft.AspNetCore.Authentication.JwtBearer
 Microsoft.AspNetCore.Authentication.Google
+Microsoft.AspNetCore.Authentication.JwtBearer
 Microsoft.AspNetCore.Authentication.MicrosoftAccount
+Microsoft.AspNetCore.Components.WebAssembly.Server
+Microsoft.AspNetCore.OpenApi
+Microsoft.EntityFrameworkCore.Design  (dev dependency)
+Microsoft.Extensions.Diagnostics.HealthChecks.EntityFrameworkCore
+Swashbuckle.AspNetCore
 Serilog.AspNetCore
-Serilog.Sinks.Console
 Serilog.Sinks.Seq
-Serilog.Sinks.Async
 Serilog.Enrichers.Environment
-Serilog.Exceptions
-Elastic.Serilog.Sinks
+Serilog.Enrichers.Thread
+Serilog.Sinks.Elasticsearch
 OpenTelemetry.Extensions.Hosting
 OpenTelemetry.Instrumentation.AspNetCore
-OpenTelemetry.Instrumentation.Http
 OpenTelemetry.Instrumentation.EntityFrameworkCore
+OpenTelemetry.Instrumentation.Http
 OpenTelemetry.Exporter.OpenTelemetryProtocol
 ```
+
+**Note:** The Application project uses `Serilog.Sinks.Elasticsearch` (the archived package), NOT `Elastic.Serilog.Sinks`. It does NOT include `Serilog.Exceptions` or `Serilog.Sinks.Async`.
 
 ### HotBox.Client
 ```


### PR DESCRIPTION
## Summary

- **5 domain agents** (Platform, Auth, Messaging, Realtime, Client) audited the full codebase against all docs and found **50+ discrepancies**
- Fixed wrong file paths, outdated config structures, missing API endpoints, stale design tokens, and inaccurate project structure across **10 files** (+1 new)
- Net result: **+1,217 / -672 lines** — docs now match the actual codebase

## What changed

**Systemic fixes (every doc):** Options paths (`Core/Options/` not `Application/Configuration/`), DI paths (`DependencyInjection/` not `Extensions/`), service paths (`Infrastructure/Services/` not `Application/Services/`), API routes (`/api/` not `/api/v1/`)

**`docs/technical-spec.md`** — largest change (~1,100 lines touched): rewrote client project structure for top-bar layout, fixed all SignalR hub method names, added 15+ missing API endpoints, added 3 missing entities (ApiKey, RefreshToken, ServerSettings), rewrote config/appsettings to match actual flat structure, fixed design tokens (teal palette not blue), fixed Docker section (port 8080, postgres:16-alpine, Seq not Elasticsearch), updated NuGet packages, added API key auth section

**`docs/ownership-domains.md`** — fixed all 5 domain code path listings

**`.claude/agents/*.md` (5 files)** — corrected code ownership, config references, hub method signatures

**`docs/implementation-plan.md`** — fixed .NET 8 (not 9), added status note, fixed paths

**`CLAUDE.md`** — updated project status and voice tech stack

**`docs/architecture/configuration-reference.md`** — **new file**: authoritative reference for all 8 config sections with property tables, defaults, env var examples

## Test plan

- [ ] Verify docs render correctly on GitHub
- [ ] Spot-check file paths referenced in technical-spec.md against actual codebase
- [ ] Spot-check API endpoints listed in Section 2.3 against actual controllers

🤖 Generated with [Claude Code](https://claude.com/claude-code)