### PR TITLE
fix: correct channel header and welcome position bugs (#100, #101)

### DIFF
--- a/src/HotBox.Client/Components/Chat/MessageList.razor
+++ b/src/HotBox.Client/Components/Chat/MessageList.razor
@@ -16,6 +16,7 @@
             </div>
         }
 
+        <div class="messages-list">
         @if (ChannelState.IsLoadingMessages)
         {
             @for (var i = 0; i < _skeletonMessages.Length; i++)
@@ -93,6 +94,7 @@
                 lastTime = msg.CreatedAtUtc;
             }
         }
+        </div>
     </div>
 </div>
 

--- a/src/HotBox.Client/Layout/MainLayout.razor
+++ b/src/HotBox.Client/Layout/MainLayout.razor
@@ -337,6 +337,9 @@
 
         if (section == "dms")
         {
+            // Clear active channel when switching to DMs
+            ChannelState.ClearActiveChannel();
+
             if (DirectMessageState.ActiveConversationUserId.HasValue)
                 Navigation.NavigateTo($"/dm/{DirectMessageState.ActiveConversationUserId.Value}");
             else
@@ -344,6 +347,9 @@
         }
         else
         {
+            // Clear active DM conversation when switching to channels
+            DirectMessageState.ClearActiveConversation();
+
             if (ChannelState.ActiveChannel is not null)
                 Navigation.NavigateTo($"/channels/{ChannelState.ActiveChannel.Id}");
             else

--- a/src/HotBox.Client/State/ChannelState.cs
+++ b/src/HotBox.Client/State/ChannelState.cs
@@ -93,5 +93,13 @@ public class ChannelState
         NotifyStateChanged();
     }
 
+    public void ClearActiveChannel()
+    {
+        ActiveChannel = null;
+        Messages = new();
+        TypingUsers = new();
+        NotifyStateChanged();
+    }
+
     private void NotifyStateChanged() => OnChange?.Invoke();
 }

--- a/src/HotBox.Client/wwwroot/css/app.css
+++ b/src/HotBox.Client/wwwroot/css/app.css
@@ -805,11 +805,17 @@ input, textarea {
 }
 
 .messages-container {
-  margin-top: auto;
   padding: 0 32px;
   max-width: 780px;
   width: 100%;
   align-self: center;
+  display: flex;
+  flex-direction: column;
+  flex: 1;
+}
+
+.messages-list {
+  margin-top: auto;
 }
 
 /* Message groups */


### PR DESCRIPTION
## Summary
- **#100**: Fixed channel welcome header stuck at bottom in empty channels by restructuring the flex layout — moved `margin-top: auto` from `.messages-container` to a new `.messages-list` wrapper div so only messages push to bottom while the welcome header stays at top
- **#101**: Fixed channel breadcrumb persisting when switching to DM view by adding `ClearActiveChannel()` to `ChannelState` and calling appropriate clear methods in `MainLayout.SwitchSection()`

## Test plan
- [ ] Open an empty text channel — welcome header should appear at the top, not the bottom
- [ ] Open a channel with messages — messages should still anchor to the bottom and scroll correctly
- [ ] Switch from a channel to DMs — header should show DM info, not the previous channel breadcrumb
- [ ] Switch from DMs back to channels — header should show channel info, not DM info

Closes #100
Closes #101

🤖 Generated with [Claude Code](https://claude.com/claude-code)