### PR TITLE
fix: agent presence from API activity (#167)

### DIFF
--- a/src/HotBox.Application/Middleware/AgentPresenceMiddleware.cs
+++ b/src/HotBox.Application/Middleware/AgentPresenceMiddleware.cs
@@ -1,0 +1,66 @@
+using System.Security.Claims;
+using HotBox.Core.Interfaces;
+using HotBox.Infrastructure.Data;
+using Microsoft.EntityFrameworkCore;
+
+namespace HotBox.Application.Middleware;
+
+public sealed class AgentPresenceMiddleware
+{
+    private readonly RequestDelegate _next;
+
+    public AgentPresenceMiddleware(RequestDelegate next)
+    {
+        _next = next;
+    }
+
+    public async Task InvokeAsync(
+        HttpContext context,
+        IPresenceService presenceService,
+        HotBoxDbContext dbContext)
+    {
+        if (context.Request.Path.StartsWithSegments("/api")
+            && context.User?.Identity?.IsAuthenticated == true)
+        {
+            await TouchAgentPresenceAsync(context, presenceService, dbContext);
+        }
+
+        await _next(context);
+    }
+
+    private static async Task TouchAgentPresenceAsync(
+        HttpContext context,
+        IPresenceService presenceService,
+        HotBoxDbContext dbContext)
+    {
+        var userIdClaim = context.User.FindFirst(ClaimTypes.NameIdentifier)?.Value;
+        if (!Guid.TryParse(userIdClaim, out var userId))
+        {
+            return;
+        }
+
+        var isAgentClaim = context.User.FindFirst("is_agent")?.Value;
+        if (bool.TryParse(isAgentClaim, out var isAgentFromClaim))
+        {
+            if (!isAgentFromClaim)
+            {
+                return;
+            }
+
+            var displayName = context.User.FindFirst("display_name")?.Value ?? "Unknown";
+            await presenceService.TouchAgentActivityAsync(userId, displayName);
+            return;
+        }
+
+        var user = await dbContext.Users
+            .AsNoTracking()
+            .Where(u => u.Id == userId)
+            .Select(u => new { u.DisplayName, u.IsAgent })
+            .FirstOrDefaultAsync(context.RequestAborted);
+
+        if (user?.IsAgent == true)
+        {
+            await presenceService.TouchAgentActivityAsync(userId, user.DisplayName);
+        }
+    }
+}

--- a/src/HotBox.Application/Program.cs
+++ b/src/HotBox.Application/Program.cs
@@ -1,5 +1,6 @@
 using HotBox.Application.DependencyInjection;
 using HotBox.Application.Hubs;
+using HotBox.Application.Middleware;
 using HotBox.Core.Enums;
 using HotBox.Core.Interfaces;
 using HotBox.Infrastructure.Data;
@@ -63,6 +64,7 @@ try
     app.UseCors();
     app.UseAuthentication();
     app.UseAuthorization();
+    app.UseMiddleware<AgentPresenceMiddleware>();
     app.MapControllers();
     app.MapHub<ChatHub>("/hubs/chat");
     app.MapHub<VoiceSignalingHub>("/hubs/voice");

--- a/src/HotBox.Application/appsettings.json
+++ b/src/HotBox.Application/appsettings.json
@@ -11,6 +11,11 @@
     "Port": 5000,
     "RegistrationMode": "InviteOnly"
   },
+  "Presence": {
+    "GracePeriod": "00:00:30",
+    "IdleTimeout": "00:05:00",
+    "AgentInactivityTimeout": "00:05:00"
+  },
   "Database": {
     "Provider": "sqlite",
     "ConnectionString": "Data Source=hotbox.db"

--- a/src/HotBox.Core/Interfaces/IPresenceService.cs
+++ b/src/HotBox.Core/Interfaces/IPresenceService.cs
@@ -45,4 +45,10 @@ public interface IPresenceService
     /// Records a heartbeat from the client, resetting the idle timer.
     /// </summary>
     void RecordHeartbeat(Guid userId);
+
+    /// <summary>
+    /// Marks an agent as active based on API activity and keeps it online
+    /// until agent inactivity timeout expires.
+    /// </summary>
+    Task TouchAgentActivityAsync(Guid userId, string displayName);
 }

--- a/src/HotBox.Core/Options/PresenceOptions.cs
+++ b/src/HotBox.Core/Options/PresenceOptions.cs
@@ -1,0 +1,12 @@
+namespace HotBox.Core.Options;
+
+public class PresenceOptions
+{
+    public const string SectionName = "Presence";
+
+    public TimeSpan GracePeriod { get; set; } = TimeSpan.FromSeconds(30);
+
+    public TimeSpan IdleTimeout { get; set; } = TimeSpan.FromMinutes(5);
+
+    public TimeSpan AgentInactivityTimeout { get; set; } = TimeSpan.FromMinutes(5);
+}

--- a/src/HotBox.Infrastructure/DependencyInjection/InfrastructureServiceExtensions.cs
+++ b/src/HotBox.Infrastructure/DependencyInjection/InfrastructureServiceExtensions.cs
@@ -25,6 +25,8 @@ public static class InfrastructureServiceExtensions
             configuration.GetSection(ServerOptions.SectionName).Bind(opts));
         services.Configure<ObservabilityOptions>(opts =>
             configuration.GetSection(ObservabilityOptions.SectionName).Bind(opts));
+        services.Configure<PresenceOptions>(opts =>
+            configuration.GetSection(PresenceOptions.SectionName).Bind(opts));
 
         // Read database options for provider configuration
         var dbOptions = configuration

--- a/src/HotBox.Infrastructure/Services/TokenService.cs
+++ b/src/HotBox.Infrastructure/Services/TokenService.cs
@@ -43,6 +43,7 @@ public class TokenService : ITokenService
             new(JwtRegisteredClaimNames.Email, user.Email ?? string.Empty),
             new(JwtRegisteredClaimNames.Jti, Guid.NewGuid().ToString()),
             new("display_name", user.DisplayName),
+            new("is_agent", user.IsAgent.ToString().ToLowerInvariant()),
         };
 
         foreach (var role in roles)

--- a/tests/HotBox.Application.Tests/HotBox.Application.Tests.csproj
+++ b/tests/HotBox.Application.Tests/HotBox.Application.Tests.csproj
@@ -12,6 +12,7 @@
   <ItemGroup>
     <PackageReference Include="coverlet.collector" Version="6.0.0" />
     <PackageReference Include="FluentAssertions" Version="6.12.0" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="9.0.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
     <PackageReference Include="NSubstitute" Version="5.1.0" />
     <PackageReference Include="xunit" Version="2.5.3" />

--- a/tests/HotBox.Application.Tests/Middleware/AgentPresenceMiddlewareTests.cs
+++ b/tests/HotBox.Application.Tests/Middleware/AgentPresenceMiddlewareTests.cs
@@ -1,0 +1,122 @@
+using System.Security.Claims;
+using FluentAssertions;
+using HotBox.Application.Middleware;
+using HotBox.Core.Entities;
+using HotBox.Core.Interfaces;
+using HotBox.Infrastructure.Data;
+using Microsoft.AspNetCore.Http;
+using Microsoft.EntityFrameworkCore;
+using NSubstitute;
+
+namespace HotBox.Application.Tests.Middleware;
+
+public class AgentPresenceMiddlewareTests
+{
+    [Fact]
+    public async Task InvokeAsync_WithAgentClaim_TouchesAgentPresence()
+    {
+        // Arrange
+        var presenceService = Substitute.For<IPresenceService>();
+        var dbContext = CreateDbContext();
+        var userId = Guid.NewGuid();
+        var httpContext = BuildHttpContext("/api/channels", userId, "true", "Agent One");
+        var nextCalled = false;
+        var middleware = new AgentPresenceMiddleware(_ =>
+        {
+            nextCalled = true;
+            return Task.CompletedTask;
+        });
+
+        // Act
+        await middleware.InvokeAsync(httpContext, presenceService, dbContext);
+
+        // Assert
+        await presenceService.Received(1).TouchAgentActivityAsync(userId, "Agent One");
+        nextCalled.Should().BeTrue();
+    }
+
+    [Fact]
+    public async Task InvokeAsync_WithoutAgentClaim_UsesDatabaseFallback()
+    {
+        // Arrange
+        var presenceService = Substitute.For<IPresenceService>();
+        var dbContext = CreateDbContext();
+        var userId = Guid.NewGuid();
+        dbContext.Users.Add(new AppUser
+        {
+            Id = userId,
+            UserName = "agent@example.com",
+            Email = "agent@example.com",
+            DisplayName = "Legacy Agent",
+            IsAgent = true,
+        });
+        await dbContext.SaveChangesAsync();
+
+        var httpContext = BuildHttpContext("/api/channels", userId, isAgentClaim: null, displayName: null);
+        var middleware = new AgentPresenceMiddleware(_ => Task.CompletedTask);
+
+        // Act
+        await middleware.InvokeAsync(httpContext, presenceService, dbContext);
+
+        // Assert
+        await presenceService.Received(1).TouchAgentActivityAsync(userId, "Legacy Agent");
+    }
+
+    [Fact]
+    public async Task InvokeAsync_WithHumanClaim_DoesNotTouchPresence()
+    {
+        // Arrange
+        var presenceService = Substitute.For<IPresenceService>();
+        var dbContext = CreateDbContext();
+        var userId = Guid.NewGuid();
+        var httpContext = BuildHttpContext("/api/channels", userId, "false", "Human User");
+        var middleware = new AgentPresenceMiddleware(_ => Task.CompletedTask);
+
+        // Act
+        await middleware.InvokeAsync(httpContext, presenceService, dbContext);
+
+        // Assert
+        await presenceService.DidNotReceiveWithAnyArgs().TouchAgentActivityAsync(default, default!);
+    }
+
+    private static HotBoxDbContext CreateDbContext()
+    {
+        var options = new DbContextOptionsBuilder<HotBoxDbContext>()
+            .UseInMemoryDatabase($"AgentPresenceMiddlewareTests_{Guid.NewGuid()}")
+            .Options;
+
+        return new HotBoxDbContext(options);
+    }
+
+    private static HttpContext BuildHttpContext(
+        string path,
+        Guid userId,
+        string? isAgentClaim,
+        string? displayName)
+    {
+        var claims = new List<Claim>
+        {
+            new(ClaimTypes.NameIdentifier, userId.ToString()),
+        };
+
+        if (isAgentClaim is not null)
+        {
+            claims.Add(new Claim("is_agent", isAgentClaim));
+        }
+
+        if (displayName is not null)
+        {
+            claims.Add(new Claim("display_name", displayName));
+        }
+
+        var identity = new ClaimsIdentity(claims, "TestAuth");
+        var principal = new ClaimsPrincipal(identity);
+
+        var context = new DefaultHttpContext
+        {
+            User = principal,
+        };
+        context.Request.Path = path;
+        return context;
+    }
+}

--- a/tests/HotBox.Infrastructure.Tests/Services/TokenServiceTests.cs
+++ b/tests/HotBox.Infrastructure.Tests/Services/TokenServiceTests.cs
@@ -72,6 +72,7 @@ public class TokenServiceTests
         jwtToken.Claims.Should().Contain(c => c.Type == JwtRegisteredClaimNames.Sub && c.Value == user.Id.ToString());
         jwtToken.Claims.Should().Contain(c => c.Type == JwtRegisteredClaimNames.Email && c.Value == user.Email);
         jwtToken.Claims.Should().Contain(c => c.Type == "display_name" && c.Value == user.DisplayName);
+        jwtToken.Claims.Should().Contain(c => c.Type == "is_agent" && c.Value == "false");
         jwtToken.Claims.Should().Contain(c => c.Type == ClaimTypes.Role && c.Value == "Member");
     }
 


### PR DESCRIPTION
## Summary
- add AgentPresenceMiddleware to touch presence on authenticated /api requests for agent users
- add IPresenceService.TouchAgentActivityAsync and implement agent-specific inactivity timeout behavior in PresenceService
- add PresenceOptions with configurable grace, idle, and agent inactivity timeouts and wire to DI and appsettings
- include is_agent claim in JWT access tokens with DB fallback in middleware for legacy tokens
- add infrastructure and application tests for middleware behavior, agent timeout, and token claim

## Validation
- flatpak-spawn --host dotnet test tests/HotBox.Infrastructure.Tests/HotBox.Infrastructure.Tests.csproj --nologo
- flatpak-spawn --host dotnet test tests/HotBox.Application.Tests/HotBox.Application.Tests.csproj --nologo

Closes #167