### PR TITLE
fix: improve DM section with auto-navigate and conversation list (#154)

### DIFF
--- a/src/HotBox.Client/Layout/MainLayout.razor
+++ b/src/HotBox.Client/Layout/MainLayout.razor
@@ -342,6 +342,12 @@
 
             if (DirectMessageState.ActiveConversationUserId.HasValue)
                 Navigation.NavigateTo($"/dm/{DirectMessageState.ActiveConversationUserId.Value}");
+            else if (DirectMessageState.Conversations.Count > 0)
+            {
+                var mostRecent = DirectMessageState.Conversations[0];
+                DirectMessageState.SetActiveConversation(mostRecent.UserId, mostRecent.DisplayName);
+                Navigation.NavigateTo($"/dm/{mostRecent.UserId}");
+            }
             else
                 Navigation.NavigateTo("/dms");
         }

--- a/src/HotBox.Client/Pages/DmsPage.razor
+++ b/src/HotBox.Client/Pages/DmsPage.razor
@@ -1,11 +1,101 @@
 @page "/dms"
+@using HotBox.Client.State
+@using HotBox.Client.Models
+@using HotBox.Client.Services
+@inject DirectMessageState DirectMessageState
+@inject ApiClient Api
+@inject NavigationManager Navigation
+@inject ILogger<DmsPage> Logger
+@implements IDisposable
 
 <PageTitle>HotBox - Direct Messages</PageTitle>
 
-<div class="page-placeholder">
-    <svg class="placeholder-icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round">
-        <path d="M21 15a2 2 0 0 1-2 2H7l-4 4V5a2 2 0 0 1 2-2h14a2 2 0 0 1 2 2z"></path>
-    </svg>
-    <h2>Direct Messages</h2>
-    <p>Select a conversation from the tabs above, or start a new one.</p>
-</div>
+@if (DirectMessageState.Conversations.Count == 0)
+{
+    <div class="page-placeholder">
+        <svg class="placeholder-icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round">
+            <path d="M21 15a2 2 0 0 1-2 2H7l-4 4V5a2 2 0 0 1 2-2h14a2 2 0 0 1 2 2z"></path>
+        </svg>
+        <h2>Direct Messages</h2>
+        <p>Select a conversation from the tabs above, or start a new one.</p>
+    </div>
+}
+else
+{
+    <div class="dms-page-container">
+        <div class="dms-page-header">
+            <h2>Recent Conversations</h2>
+        </div>
+        <div class="dms-page-list">
+            @foreach (var conversation in DirectMessageState.Conversations)
+            {
+                <button class="dms-page-item" @onclick="() => SelectConversation(conversation)">
+                    <div class="dms-page-item-main">
+                        <div class="dms-page-item-name">@conversation.DisplayName</div>
+                        <div class="dms-page-item-preview">@(string.IsNullOrWhiteSpace(conversation.LastMessageContent) ? "No messages yet" : conversation.LastMessageContent)</div>
+                    </div>
+                    <div class="dms-page-item-meta">
+                        <div class="dms-page-item-time">@FormatTimestamp(conversation.LastMessageAtUtc)</div>
+                        @if (conversation.UnreadCount > 0)
+                        {
+                            <span class="unread-badge">@conversation.UnreadCount</span>
+                        }
+                    </div>
+                </button>
+            }
+        </div>
+    </div>
+}
+
+@code {
+    private bool _loaded;
+
+    protected override async Task OnInitializedAsync()
+    {
+        DirectMessageState.OnChange += StateHasChanged;
+
+        // Load conversations if not already loaded
+        if (!_loaded && DirectMessageState.Conversations.Count == 0)
+        {
+            _loaded = true;
+            try
+            {
+                var conversations = await Api.GetConversationsAsync();
+                DirectMessageState.SetConversations(conversations);
+            }
+            catch (Exception ex)
+            {
+                Logger.LogError(ex, "Failed to load conversations");
+            }
+        }
+    }
+
+    private void SelectConversation(ConversationSummaryResponse conversation)
+    {
+        DirectMessageState.SetActiveConversation(conversation.UserId, conversation.DisplayName);
+        Navigation.NavigateTo($"/dm/{conversation.UserId}");
+    }
+
+    private string FormatTimestamp(DateTime utc)
+    {
+        var local = utc.ToLocalTime();
+        var now = DateTime.Now;
+        var diff = now - local;
+
+        if (diff.TotalMinutes < 1)
+            return "Just now";
+        if (diff.TotalMinutes < 60)
+            return $"{(int)diff.TotalMinutes}m ago";
+        if (diff.TotalHours < 24)
+            return $"{(int)diff.TotalHours}h ago";
+        if (diff.TotalDays < 7)
+            return $"{(int)diff.TotalDays}d ago";
+
+        return local.ToString("MMM d");
+    }
+
+    public void Dispose()
+    {
+        DirectMessageState.OnChange -= StateHasChanged;
+    }
+}

--- a/src/HotBox.Client/wwwroot/css/app.css
+++ b/src/HotBox.Client/wwwroot/css/app.css
@@ -1316,6 +1316,108 @@ input, textarea {
 }
 
 /* ========================================
+   DMs Page Conversation List
+   ======================================== */
+.dms-page-container {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  padding: 32px 16px;
+  height: 100%;
+  overflow-y: auto;
+}
+
+.dms-page-header {
+  width: 100%;
+  max-width: 500px;
+  margin-bottom: 16px;
+}
+
+.dms-page-header h2 {
+  font-size: 18px;
+  font-weight: 600;
+  color: var(--text-primary);
+  margin: 0;
+}
+
+.dms-page-list {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  width: 100%;
+  max-width: 500px;
+}
+
+.dms-page-item {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  border: none;
+  font: inherit;
+  text-align: left;
+  width: 100%;
+  gap: 12px;
+  padding: 12px 16px;
+  background: var(--bg-surface);
+  border-radius: var(--radius-md);
+  cursor: pointer;
+  transition: background-color var(--transition-fast);
+}
+
+.dms-page-item:hover {
+  background: var(--bg-hover);
+}
+
+.dms-page-item-main {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  flex: 1;
+  min-width: 0;
+}
+
+.dms-page-item-name {
+  font-size: 14px;
+  font-weight: 500;
+  color: var(--text-primary);
+}
+
+.dms-page-item-preview {
+  font-size: 13px;
+  color: var(--text-muted);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.dms-page-item-meta {
+  display: flex;
+  flex-direction: column;
+  align-items: flex-end;
+  gap: 4px;
+  flex-shrink: 0;
+}
+
+.dms-page-item-time {
+  font-size: 11px;
+  color: var(--text-muted);
+}
+
+.unread-badge {
+  background: var(--accent);
+  color: var(--bg-deepest);
+  font-size: 10px;
+  font-weight: 700;
+  min-width: 16px;
+  height: 16px;
+  border-radius: var(--radius-pill);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 0 5px;
+}
+
+/* ========================================
    New DM Picker & Button
    ======================================== */
 .new-dm-btn {


### PR DESCRIPTION
## Summary
This PR improves the DM section user experience by adding auto-navigation to the most recent conversation and replacing the static placeholder with a rich conversation list.

### Changes
- **MainLayout.razor**: Modified `SwitchSection("dms")` to auto-navigate to the most recent conversation when conversations are already loaded, instead of always landing on the `/dms` placeholder
- **DmsPage.razor**: Complete rewrite with conversation list showing:
  - Display name
  - Last message preview with fallback text ("No messages yet")
  - Relative timestamp ("2h ago", "Just now", etc.)
  - Unread badge when unread count > 0
  - Preserved empty state when no conversations exist
- **app.css**: Added `.dms-page-*` styles for conversation list layout and missing `.unread-badge` class
- Used `<button>` elements for conversation items (accessibility/keyboard navigation)

## Review Status
- Code Review: APPROVED (after addressing critical/major issues)
- UI Review: SKIPPED (no screenshots available)

Closes #154

🤖 Generated with [Claude Code](https://claude.com/claude-code)