### PR TITLE
feat: add message virtualization with scroll-up pagination and purge (#164)

### DIFF
--- a/src/HotBox.Client/Components/Chat/DirectMessageMessageList.razor
+++ b/src/HotBox.Client/Components/Chat/DirectMessageMessageList.razor
@@ -6,7 +6,7 @@
 
 <div class="messages-area">
     <div class="messages-container">
-        @if (DirectMessageState.ActiveConversationUserId is not null)
+        @if (DirectMessageState.ActiveConversationUserId is not null && !DirectMessageState.HasMoreMessages)
         {
             <div class="channel-welcome">
                 <h2>@@ @DirectMessageState.ActiveConversationDisplayName</h2>
@@ -24,6 +24,13 @@
         }
         else
         {
+            @if (DirectMessageState.IsLoadingOlderMessages)
+            {
+                <div class="pagination-loader">
+                    <span class="spinner"></span>
+                </div>
+            }
+
             string? lastAuthor = null;
             DateTime? lastTime = null;
 
@@ -67,8 +74,12 @@
 </div>
 
 @code {
+    [Parameter]
+    public EventCallback OnScrollNearTop { get; set; }
+
     private bool _forceScroll;
     private bool _wasLoading;
+    private DateTime _lastScrollCheck = DateTime.MinValue;
 
     protected override void OnInitialized()
     {
@@ -87,14 +98,33 @@
 
     protected override async Task OnAfterRenderAsync(bool firstRender)
     {
-        if (_forceScroll)
+        // Skip auto-scroll during older messages loading to preserve scroll position
+        if (!DirectMessageState.IsLoadingOlderMessages)
         {
-            _forceScroll = false;
-            await JS.InvokeVoidAsync("chatInterop.scrollToBottom", ".messages-area");
+            if (_forceScroll)
+            {
+                _forceScroll = false;
+                await JS.InvokeVoidAsync("chatInterop.scrollToBottom", ".messages-area");
+            }
+            else if (DirectMessageState.Messages.Count > 0)
+            {
+                await JS.InvokeVoidAsync("chatInterop.scrollToBottomIfNearEnd", ".messages-area", 150);
+            }
         }
-        else if (DirectMessageState.Messages.Count > 0)
+
+        // Check if user has scrolled near top (debounced)
+        if (!DirectMessageState.IsLoadingMessages && !DirectMessageState.IsLoadingOlderMessages)
         {
-            await JS.InvokeVoidAsync("chatInterop.scrollToBottomIfNearEnd", ".messages-area", 150);
+            var now = DateTime.UtcNow;
+            if ((now - _lastScrollCheck).TotalMilliseconds >= 500)
+            {
+                _lastScrollCheck = now;
+                var isNearTop = await JS.InvokeAsync<bool>("chatInterop.isNearTop", ".messages-area", 100);
+                if (isNearTop)
+                {
+                    await OnScrollNearTop.InvokeAsync();
+                }
+            }
         }
     }
 

--- a/src/HotBox.Client/Components/Chat/MessageList.razor
+++ b/src/HotBox.Client/Components/Chat/MessageList.razor
@@ -6,7 +6,7 @@
 
 <div class="messages-area">
     <div class="messages-container">
-        @if (ChannelState.ActiveChannel is not null)
+        @if (ChannelState.ActiveChannel is not null && !ChannelState.HasMoreMessages)
         {
             <div class="channel-welcome">
                 <h2># @ChannelState.ActiveChannel.Name</h2>
@@ -104,6 +104,9 @@
 }
 
 @code {
+    [Parameter]
+    public EventCallback OnScrollNearTop { get; set; }
+
     private record SkeletonMessageDef(int AuthorWidth, int Line1Width, int Line2Width);
 
     private static readonly SkeletonMessageDef[] _skeletonMessages =
@@ -118,6 +121,7 @@
 
     private bool _forceScroll;
     private bool _wasLoading;
+    private DateTime _lastScrollCheck = DateTime.MinValue;
     private Guid? _selectedAuthorId;
     private double _anchorX;
     private double _anchorY;
@@ -140,14 +144,33 @@
 
     protected override async Task OnAfterRenderAsync(bool firstRender)
     {
-        if (_forceScroll)
+        // Skip auto-scroll during older messages loading to preserve scroll position
+        if (!ChannelState.IsLoadingOlderMessages)
         {
-            _forceScroll = false;
-            await JS.InvokeVoidAsync("chatInterop.scrollToBottom", ".messages-area");
+            if (_forceScroll)
+            {
+                _forceScroll = false;
+                await JS.InvokeVoidAsync("chatInterop.scrollToBottom", ".messages-area");
+            }
+            else if (ChannelState.Messages.Count > 0)
+            {
+                await JS.InvokeVoidAsync("chatInterop.scrollToBottomIfNearEnd", ".messages-area", 150);
+            }
         }
-        else if (ChannelState.Messages.Count > 0)
+
+        // Check if user has scrolled near top (debounced)
+        if (!ChannelState.IsLoadingMessages && !ChannelState.IsLoadingOlderMessages)
         {
-            await JS.InvokeVoidAsync("chatInterop.scrollToBottomIfNearEnd", ".messages-area", 150);
+            var now = DateTime.UtcNow;
+            if ((now - _lastScrollCheck).TotalMilliseconds >= 500)
+            {
+                _lastScrollCheck = now;
+                var isNearTop = await JS.InvokeAsync<bool>("chatInterop.isNearTop", ".messages-area", 100);
+                if (isNearTop)
+                {
+                    await OnScrollNearTop.InvokeAsync();
+                }
+            }
         }
     }
 

--- a/src/HotBox.Client/Pages/ChannelPage.razor
+++ b/src/HotBox.Client/Pages/ChannelPage.razor
@@ -5,11 +5,12 @@
 @inject ChannelState ChannelState
 @inject ApiClient Api
 @inject ChatHubService ChatHub
+@inject IJSRuntime JS
 @implements IDisposable
 
 <PageTitle>HotBox - @(ChannelState.ActiveChannel?.Name ?? "Channel")</PageTitle>
 
-<MessageList />
+<MessageList OnScrollNearTop="LoadOlderMessages" />
 <MessageInput />
 
 @code {
@@ -17,6 +18,8 @@
     public Guid Id { get; set; }
 
     private Guid _currentChannelId;
+    private double _previousScrollHeight;
+    private bool _pendingScrollRestore;
 
     protected override void OnInitialized()
     {
@@ -52,10 +55,17 @@
 
         // Load messages for this channel
         ChannelState.SetLoadingMessages(true);
+        ChannelState.SetHasMoreMessages(true);
         try
         {
             var messages = await Api.GetMessagesAsync(Id);
             ChannelState.SetMessages(messages);
+
+            // If we got less than the default limit (50), we've loaded all messages
+            if (messages.Count < 50)
+            {
+                ChannelState.SetHasMoreMessages(false);
+            }
         }
         finally
         {
@@ -76,6 +86,13 @@
             // Clear typing indicator for the author who just sent a message
             ChannelState.RemoveTypingUser(message.AuthorId);
             ChannelState.AddMessage(message);
+
+            // Purge oldest messages if beyond window (user is near bottom receiving new messages)
+            if (ChannelState.Messages.Count > ChannelState.MessageWindowSize)
+            {
+                ChannelState.PurgeOldMessages(ChannelState.MessageWindowSize);
+            }
+
             InvokeAsync(StateHasChanged);
         }
     }
@@ -97,6 +114,75 @@
             InvokeAsync(StateHasChanged);
         }
     }
+
+    private async Task LoadOlderMessages()
+    {
+        // Guard: don't load if already loading, no more messages, or no messages yet
+        if (ChannelState.IsLoadingOlderMessages || !ChannelState.HasMoreMessages || ChannelState.Messages.Count == 0)
+            return;
+
+        ChannelState.SetLoadingOlderMessages(true);
+        try
+        {
+            // Get the oldest message timestamp
+            var oldestMessage = ChannelState.Messages[0];
+            var before = oldestMessage.CreatedAtUtc;
+
+            // Save scroll position before prepending
+            var scrollInfo = await JS.InvokeAsync<ScrollPosition>("chatInterop.getScrollPosition", ".messages-area");
+            _previousScrollHeight = scrollInfo.ScrollHeight;
+
+            // Fetch older messages
+            var olderMessages = await Api.GetMessagesAsync(_currentChannelId, before: before, limit: 50);
+
+            if (olderMessages.Count > 0)
+            {
+                // Prepend messages to state
+                ChannelState.PrependMessages(olderMessages);
+
+                // If we got less than requested, we've reached the beginning
+                if (olderMessages.Count < 50)
+                {
+                    ChannelState.SetHasMoreMessages(false);
+                }
+
+                // Schedule scroll position restoration for next render
+                _pendingScrollRestore = true;
+                StateHasChanged();
+
+                // User is scrolled up (loaded older messages) — purge newest messages from end if beyond window
+                if (ChannelState.Messages.Count > ChannelState.MessageWindowSize)
+                {
+                    ChannelState.PurgeNewMessages(ChannelState.MessageWindowSize);
+                }
+            }
+            else
+            {
+                ChannelState.SetHasMoreMessages(false);
+            }
+        }
+        finally
+        {
+            ChannelState.SetLoadingOlderMessages(false);
+        }
+    }
+
+    protected override async Task OnAfterRenderAsync(bool firstRender)
+    {
+        if (_pendingScrollRestore)
+        {
+            _pendingScrollRestore = false;
+
+            // Restore scroll position after prepend
+            var newScrollInfo = await JS.InvokeAsync<ScrollPosition>("chatInterop.getScrollPosition", ".messages-area");
+            var scrollDelta = newScrollInfo.ScrollHeight - _previousScrollHeight;
+            var newScrollTop = newScrollInfo.ScrollTop + scrollDelta;
+
+            await JS.InvokeVoidAsync("chatInterop.setScrollTop", ".messages-area", newScrollTop);
+        }
+    }
+
+    private record ScrollPosition(double ScrollTop, double ScrollHeight, double ClientHeight);
 
     public void Dispose()
     {

--- a/src/HotBox.Client/Pages/DirectMessagePage.razor
+++ b/src/HotBox.Client/Pages/DirectMessagePage.razor
@@ -6,11 +6,12 @@
 @inject AuthState AuthState
 @inject ApiClient Api
 @inject ChatHubService ChatHub
+@inject IJSRuntime JS
 @implements IDisposable
 
 <PageTitle>HotBox - DM with @(DirectMessageState.ActiveConversationDisplayName ?? "User")</PageTitle>
 
-<DirectMessageMessageList />
+<DirectMessageMessageList OnScrollNearTop="LoadOlderMessages" />
 <DirectMessageInput />
 
 @code {
@@ -18,6 +19,8 @@
     public Guid UserId { get; set; }
 
     private Guid _currentUserId;
+    private double _previousScrollHeight;
+    private bool _pendingScrollRestore;
 
     protected override void OnInitialized()
     {
@@ -55,10 +58,17 @@
 
         // Load messages for this conversation
         DirectMessageState.SetLoadingMessages(true);
+        DirectMessageState.SetHasMoreMessages(true);
         try
         {
             var messages = await Api.GetDirectMessagesAsync(UserId);
             DirectMessageState.SetMessages(messages);
+
+            // If we got less than the default limit (50), we've loaded all messages
+            if (messages.Count < 50)
+            {
+                DirectMessageState.SetHasMoreMessages(false);
+            }
         }
         finally
         {
@@ -74,6 +84,13 @@
              message.RecipientId == DirectMessageState.ActiveConversationUserId.Value))
         {
             DirectMessageState.AddMessage(message);
+
+            // Purge oldest messages if beyond window (user is near bottom receiving new messages)
+            if (DirectMessageState.Messages.Count > DirectMessageState.MessageWindowSize)
+            {
+                DirectMessageState.PurgeOldMessages(DirectMessageState.MessageWindowSize);
+            }
+
             InvokeAsync(StateHasChanged);
         }
     }
@@ -97,6 +114,75 @@
             InvokeAsync(StateHasChanged);
         }
     }
+
+    private async Task LoadOlderMessages()
+    {
+        // Guard: don't load if already loading, no more messages, or no messages yet
+        if (DirectMessageState.IsLoadingOlderMessages || !DirectMessageState.HasMoreMessages || DirectMessageState.Messages.Count == 0)
+            return;
+
+        DirectMessageState.SetLoadingOlderMessages(true);
+        try
+        {
+            // Get the oldest message timestamp
+            var oldestMessage = DirectMessageState.Messages[0];
+            var before = oldestMessage.CreatedAtUtc;
+
+            // Save scroll position before prepending
+            var scrollInfo = await JS.InvokeAsync<ScrollPosition>("chatInterop.getScrollPosition", ".messages-area");
+            _previousScrollHeight = scrollInfo.ScrollHeight;
+
+            // Fetch older messages
+            var olderMessages = await Api.GetDirectMessagesAsync(UserId, before: before, limit: 50);
+
+            if (olderMessages.Count > 0)
+            {
+                // Prepend messages to state
+                DirectMessageState.PrependMessages(olderMessages);
+
+                // If we got less than requested, we've reached the beginning
+                if (olderMessages.Count < 50)
+                {
+                    DirectMessageState.SetHasMoreMessages(false);
+                }
+
+                // Schedule scroll position restoration for next render
+                _pendingScrollRestore = true;
+                StateHasChanged();
+
+                // User is scrolled up (loaded older messages) — purge newest messages from end if beyond window
+                if (DirectMessageState.Messages.Count > DirectMessageState.MessageWindowSize)
+                {
+                    DirectMessageState.PurgeNewMessages(DirectMessageState.MessageWindowSize);
+                }
+            }
+            else
+            {
+                DirectMessageState.SetHasMoreMessages(false);
+            }
+        }
+        finally
+        {
+            DirectMessageState.SetLoadingOlderMessages(false);
+        }
+    }
+
+    protected override async Task OnAfterRenderAsync(bool firstRender)
+    {
+        if (_pendingScrollRestore)
+        {
+            _pendingScrollRestore = false;
+
+            // Restore scroll position after prepend
+            var newScrollInfo = await JS.InvokeAsync<ScrollPosition>("chatInterop.getScrollPosition", ".messages-area");
+            var scrollDelta = newScrollInfo.ScrollHeight - _previousScrollHeight;
+            var newScrollTop = newScrollInfo.ScrollTop + scrollDelta;
+
+            await JS.InvokeVoidAsync("chatInterop.setScrollTop", ".messages-area", newScrollTop);
+        }
+    }
+
+    private record ScrollPosition(double ScrollTop, double ScrollHeight, double ClientHeight);
 
     public void Dispose()
     {

--- a/src/HotBox.Client/wwwroot/js/chat-interop.js
+++ b/src/HotBox.Client/wwwroot/js/chat-interop.js
@@ -18,5 +18,32 @@ window.chatInterop = {
 
     getViewportSize: function () {
         return { width: window.innerWidth, height: window.innerHeight };
+    },
+
+    getScrollPosition: function (selector) {
+        const el = document.querySelector(selector);
+        if (!el) {
+            return { scrollTop: 0, scrollHeight: 0, clientHeight: 0 };
+        }
+        return {
+            scrollTop: el.scrollTop,
+            scrollHeight: el.scrollHeight,
+            clientHeight: el.clientHeight
+        };
+    },
+
+    setScrollTop: function (selector, value) {
+        const el = document.querySelector(selector);
+        if (el) {
+            el.scrollTop = value;
+        }
+    },
+
+    isNearTop: function (selector, threshold) {
+        const el = document.querySelector(selector);
+        if (!el) return false;
+
+        const thresholdValue = threshold !== undefined ? threshold : 100;
+        return el.scrollTop <= thresholdValue;
     }
 };


### PR DESCRIPTION
## Summary

- **JS interop** (`chat-interop.js`): Added `getScrollPosition`, `setScrollTop`, and `isNearTop` functions for scroll detection and position preservation
- **State management** (`ChannelState.cs`, `DirectMessageState.cs`): Added `HasMoreMessages` flag, `IsLoadingOlderMessages` (DM), directional `PurgeOldMessages`/`PurgeNewMessages` with 200-message window, and deduplication in `PrependMessages`
- **Channel pagination** (`MessageList.razor`, `ChannelPage.razor`): Scroll-near-top detection triggers `LoadOlderMessages` with debounce, scroll position preservation after prepend, directional purging
- **DM pagination** (`DirectMessageMessageList.razor`, `DirectMessagePage.razor`): Mirrors channel implementation using `DirectMessageState`
- "Beginning of channel/conversation" indicator shown only when all history is loaded

Closes #164, closes #178, closes #179, closes #180, closes #181

## Test plan

- [ ] Open a channel with 50+ messages — scroll to top triggers loading older messages with spinner
- [ ] Scroll position is preserved after older messages prepend (no visual jump)
- [ ] "This is the start of #channel" message appears only when all history is loaded
- [ ] After loading 200+ messages, oldest messages are purged when scrolling back to bottom
- [ ] New real-time messages still auto-scroll when near bottom
- [ ] New real-time messages trigger old message purge when beyond 200-message window
- [ ] Repeat all above for DM conversations
- [ ] Verify no duplicate messages appear on rapid scroll-up

🤖 Generated with [Claude Code](https://claude.com/claude-code)