### PR TITLE
feat: polish @mention system with autocomplete, structured markers, and rendering

### DIFF
--- a/src/HotBox.Client/Components/Chat/DirectMessageInput.razor
+++ b/src/HotBox.Client/Components/Chat/DirectMessageInput.razor
@@ -2,16 +2,43 @@
 @using HotBox.Client.Services
 @inject DirectMessageState DirectMessageState
 @inject ChatHubService ChatHub
+@inject PresenceState PresenceState
 @implements IDisposable
 
 <div class="message-input-wrapper">
-    <div class="message-input">
+    <div class="message-input" style="position: relative;">
+        @if (_showAutocomplete && _autocompleteResults.Count > 0)
+        {
+            <div class="mention-autocomplete" id="mention-autocomplete" role="listbox" aria-label="User suggestions">
+                @for (var i = 0; i < _autocompleteResults.Count; i++)
+                {
+                    var index = i;
+                    var user = _autocompleteResults[i];
+                    <div class="mention-autocomplete-item @(i == _selectedIndex ? "selected" : "")"
+                         role="option"
+                         aria-selected="@(i == _selectedIndex ? "true" : "false")"
+                         @onmousedown="() => SelectMention(index)"
+                         @onmousedown:preventDefault>
+                        <span class="mention-display-name">@user.DisplayName</span>
+                        @if (user.IsAgent)
+                        {
+                            <span class="mention-badge">BOT</span>
+                        }
+                    </div>
+                }
+            </div>
+        }
         <input type="text"
                @bind="MessageText"
                @bind:event="oninput"
+               @bind:after="OnInput"
                @onkeydown="HandleKeyDown"
+               @onkeydown:preventDefault="_preventKeyDefault"
                placeholder="@GetPlaceholder()"
-               disabled="@(DirectMessageState.ActiveConversationUserId is null)" />
+               disabled="@(DirectMessageState.ActiveConversationUserId is null)"
+               aria-autocomplete="list"
+               aria-expanded="@_showAutocomplete"
+               aria-controls="mention-autocomplete" />
         <button @onclick="SendMessage"
                 disabled="@(DirectMessageState.ActiveConversationUserId is null)"
                 aria-label="Send message">
@@ -34,6 +61,14 @@
     private DateTime _lastTypingSignal = DateTime.MinValue;
     private static readonly TimeSpan TypingDebounceInterval = TimeSpan.FromSeconds(3);
 
+    // Mention autocomplete state
+    private bool _showAutocomplete;
+    private string _autocompleteQuery = string.Empty;
+    private int _mentionStartIndex;
+    private List<UserPresenceInfo> _autocompleteResults = new();
+    private int _selectedIndex;
+    private bool _preventKeyDefault;
+
     protected override void OnInitialized()
     {
         DirectMessageState.OnChange += StateHasChanged;
@@ -47,16 +82,96 @@
         return $"Message @{DirectMessageState.ActiveConversationDisplayName}";
     }
 
+    private void OnInput()
+    {
+        UpdateAutocomplete();
+    }
+
+    private void UpdateAutocomplete()
+    {
+        var lastAtIndex = MessageText.LastIndexOf('@');
+
+        if (lastAtIndex >= 0 && (lastAtIndex == 0 || char.IsWhiteSpace(MessageText[lastAtIndex - 1])))
+        {
+            var query = MessageText[(lastAtIndex + 1)..];
+
+            if (!query.Contains(' '))
+            {
+                _mentionStartIndex = lastAtIndex;
+                _autocompleteQuery = query;
+                _autocompleteResults = PresenceState.GetAllUsers()
+                    .Where(u => u.DisplayName.Contains(query, StringComparison.OrdinalIgnoreCase))
+                    .Take(8)
+                    .ToList();
+                _showAutocomplete = _autocompleteResults.Count > 0;
+                _selectedIndex = 0;
+                return;
+            }
+        }
+
+        CloseAutocomplete();
+    }
+
     private async Task HandleKeyDown(Microsoft.AspNetCore.Components.Web.KeyboardEventArgs e)
     {
+        _preventKeyDefault = false;
+
+        if (_showAutocomplete && _autocompleteResults.Count > 0)
+        {
+            switch (e.Key)
+            {
+                case "ArrowUp":
+                    _selectedIndex = (_selectedIndex - 1 + _autocompleteResults.Count) % _autocompleteResults.Count;
+                    _preventKeyDefault = true;
+                    return;
+                case "ArrowDown":
+                    _selectedIndex = (_selectedIndex + 1) % _autocompleteResults.Count;
+                    _preventKeyDefault = true;
+                    return;
+                case "Enter":
+                case "Tab":
+                    SelectMention(_selectedIndex);
+                    _preventKeyDefault = true;
+                    return;
+                case "Escape":
+                    CloseAutocomplete();
+                    _preventKeyDefault = true;
+                    return;
+            }
+        }
+
         if (e.Key == "Enter" && !e.ShiftKey)
         {
+            _preventKeyDefault = true;
             await SendMessage();
             return;
         }
 
         // Debounced typing indicator
         await SendTypingSignalAsync();
+    }
+
+    private void SelectMention(int index)
+    {
+        if (index < 0 || index >= _autocompleteResults.Count)
+            return;
+
+        var user = _autocompleteResults[index];
+        var mentionMarker = $"@[{user.DisplayName}]({user.UserId}) ";
+
+        var endOfQuery = _mentionStartIndex + 1 + _autocompleteQuery.Length;
+        MessageText = MessageText[.._mentionStartIndex] + mentionMarker + MessageText[endOfQuery..];
+
+        CloseAutocomplete();
+        StateHasChanged();
+    }
+
+    private void CloseAutocomplete()
+    {
+        _showAutocomplete = false;
+        _autocompleteQuery = string.Empty;
+        _autocompleteResults.Clear();
+        _selectedIndex = 0;
     }
 
     private async Task SendMessage()

--- a/src/HotBox.Client/Components/Chat/DirectMessageMessageList.razor
+++ b/src/HotBox.Client/Components/Chat/DirectMessageMessageList.razor
@@ -1,6 +1,8 @@
 @using HotBox.Client.State
 @using HotBox.Client.Models
+@using System.Text.RegularExpressions
 @inject DirectMessageState DirectMessageState
+@inject AuthState AuthState
 @inject IJSRuntime JS
 @implements IDisposable
 
@@ -41,7 +43,7 @@
 
                 if (isNewAuthor)
                 {
-                    <div class="message-group new-author">
+                    <div class="message-group new-author @(ContainsMentionOfCurrentUser(msg.Content) ? "mentioned" : "")">
                         <div class="msg-avatar" style="background: @GetAvatarColor(msg.SenderDisplayName);">
                             @GetInitials(msg.SenderDisplayName)
                         </div>
@@ -52,16 +54,16 @@
                                 </span>
                                 <span class="msg-timestamp">@FormatTime(msg.CreatedAtUtc)</span>
                             </div>
-                            <div class="msg-body">@msg.Content</div>
+                            <div class="msg-body">@RenderMessageContent(msg.Content)</div>
                         </div>
                     </div>
                 }
                 else
                 {
-                    <div class="message-group">
+                    <div class="message-group @(ContainsMentionOfCurrentUser(msg.Content) ? "mentioned" : "")">
                         <div style="width: 34px; flex-shrink: 0;"></div>
                         <div class="msg-content">
-                            <div class="msg-body">@msg.Content</div>
+                            <div class="msg-body">@RenderMessageContent(msg.Content)</div>
                         </div>
                     </div>
                 }
@@ -153,6 +155,51 @@
         return displayName.Length >= 2
             ? displayName[..2].ToUpper()
             : displayName.ToUpper();
+    }
+
+    private static readonly Regex MentionRegex = new(@"@\[([^\]]+)\]\(([0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12})\)", RegexOptions.Compiled);
+
+    private RenderFragment RenderMessageContent(string content) => builder =>
+    {
+        var lastIndex = 0;
+        var seq = 0;
+
+        foreach (Match match in MentionRegex.Matches(content))
+        {
+            if (match.Index > lastIndex)
+            {
+                builder.AddContent(seq++, content[lastIndex..match.Index]);
+            }
+
+            var displayName = match.Groups[1].Value;
+            var userId = match.Groups[2].Value;
+            var isSelf = AuthState.CurrentUser?.Id.ToString() == userId;
+
+            builder.OpenElement(seq++, "span");
+            builder.AddAttribute(seq++, "class", isSelf ? "mention mention-self" : "mention");
+            builder.AddContent(seq++, $"@{displayName}");
+            builder.CloseElement();
+
+            lastIndex = match.Index + match.Length;
+        }
+
+        if (lastIndex < content.Length)
+        {
+            builder.AddContent(seq++, content[lastIndex..]);
+        }
+    };
+
+    private bool ContainsMentionOfCurrentUser(string content)
+    {
+        var currentUserId = AuthState.CurrentUser?.Id.ToString();
+        if (currentUserId is null) return false;
+
+        foreach (Match match in MentionRegex.Matches(content))
+        {
+            if (match.Groups[2].Value == currentUserId)
+                return true;
+        }
+        return false;
     }
 
     public void Dispose()

--- a/src/HotBox.Client/Components/Chat/MessageInput.razor
+++ b/src/HotBox.Client/Components/Chat/MessageInput.razor
@@ -2,16 +2,43 @@
 @using HotBox.Client.Services
 @inject ChannelState ChannelState
 @inject ChatHubService ChatHub
+@inject PresenceState PresenceState
 @implements IDisposable
 
 <div class="message-input-wrapper">
-    <div class="message-input">
+    <div class="message-input" style="position: relative;">
+        @if (_showAutocomplete && _autocompleteResults.Count > 0)
+        {
+            <div class="mention-autocomplete" id="mention-autocomplete" role="listbox" aria-label="User suggestions">
+                @for (var i = 0; i < _autocompleteResults.Count; i++)
+                {
+                    var index = i;
+                    var user = _autocompleteResults[i];
+                    <div class="mention-autocomplete-item @(i == _selectedIndex ? "selected" : "")"
+                         role="option"
+                         aria-selected="@(i == _selectedIndex ? "true" : "false")"
+                         @onmousedown="() => SelectMention(index)"
+                         @onmousedown:preventDefault>
+                        <span class="mention-display-name">@user.DisplayName</span>
+                        @if (user.IsAgent)
+                        {
+                            <span class="mention-badge">BOT</span>
+                        }
+                    </div>
+                }
+            </div>
+        }
         <input type="text"
                @bind="MessageText"
                @bind:event="oninput"
+               @bind:after="OnInput"
                @onkeydown="HandleKeyDown"
+               @onkeydown:preventDefault="_preventKeyDefault"
                placeholder="@GetPlaceholder()"
-               disabled="@(ChannelState.ActiveChannel is null)" />
+               disabled="@(ChannelState.ActiveChannel is null)"
+               aria-autocomplete="list"
+               aria-expanded="@_showAutocomplete"
+               aria-controls="mention-autocomplete" />
         <button @onclick="SendMessage"
                 disabled="@(ChannelState.ActiveChannel is null)"
                 aria-label="Send message">
@@ -29,6 +56,14 @@
     private DateTime _lastTypingSignal = DateTime.MinValue;
     private static readonly TimeSpan TypingDebounceInterval = TimeSpan.FromSeconds(3);
 
+    // Mention autocomplete state
+    private bool _showAutocomplete;
+    private string _autocompleteQuery = string.Empty;
+    private int _mentionStartIndex;
+    private List<UserPresenceInfo> _autocompleteResults = new();
+    private int _selectedIndex;
+    private bool _preventKeyDefault;
+
     protected override void OnInitialized()
     {
         ChannelState.OnChange += StateHasChanged;
@@ -42,16 +77,98 @@
         return $"Message #{ChannelState.ActiveChannel.Name}";
     }
 
+    private void OnInput()
+    {
+        UpdateAutocomplete();
+    }
+
+    private void UpdateAutocomplete()
+    {
+        // Find last '@' in the text
+        var lastAtIndex = MessageText.LastIndexOf('@');
+
+        if (lastAtIndex >= 0 && (lastAtIndex == 0 || char.IsWhiteSpace(MessageText[lastAtIndex - 1])))
+        {
+            var query = MessageText[(lastAtIndex + 1)..];
+
+            if (!query.Contains(' '))
+            {
+                _mentionStartIndex = lastAtIndex;
+                _autocompleteQuery = query;
+                _autocompleteResults = PresenceState.GetAllUsers()
+                    .Where(u => u.DisplayName.Contains(query, StringComparison.OrdinalIgnoreCase))
+                    .Take(8)
+                    .ToList();
+                _showAutocomplete = _autocompleteResults.Count > 0;
+                _selectedIndex = 0;
+                return;
+            }
+        }
+
+        CloseAutocomplete();
+    }
+
     private async Task HandleKeyDown(Microsoft.AspNetCore.Components.Web.KeyboardEventArgs e)
     {
+        _preventKeyDefault = false;
+
+        if (_showAutocomplete && _autocompleteResults.Count > 0)
+        {
+            switch (e.Key)
+            {
+                case "ArrowUp":
+                    _selectedIndex = (_selectedIndex - 1 + _autocompleteResults.Count) % _autocompleteResults.Count;
+                    _preventKeyDefault = true;
+                    return;
+                case "ArrowDown":
+                    _selectedIndex = (_selectedIndex + 1) % _autocompleteResults.Count;
+                    _preventKeyDefault = true;
+                    return;
+                case "Enter":
+                case "Tab":
+                    SelectMention(_selectedIndex);
+                    _preventKeyDefault = true;
+                    return;
+                case "Escape":
+                    CloseAutocomplete();
+                    _preventKeyDefault = true;
+                    return;
+            }
+        }
+
         if (e.Key == "Enter" && !e.ShiftKey)
         {
+            _preventKeyDefault = true;
             await SendMessage();
             return;
         }
 
         // Debounced typing indicator
         await SendTypingSignalAsync();
+    }
+
+    private void SelectMention(int index)
+    {
+        if (index < 0 || index >= _autocompleteResults.Count)
+            return;
+
+        var user = _autocompleteResults[index];
+        var mentionMarker = $"@[{user.DisplayName}]({user.UserId}) ";
+
+        // Replace from the '@' to the end of the query with the mention marker
+        var endOfQuery = _mentionStartIndex + 1 + _autocompleteQuery.Length;
+        MessageText = MessageText[.._mentionStartIndex] + mentionMarker + MessageText[endOfQuery..];
+
+        CloseAutocomplete();
+        StateHasChanged();
+    }
+
+    private void CloseAutocomplete()
+    {
+        _showAutocomplete = false;
+        _autocompleteQuery = string.Empty;
+        _autocompleteResults.Clear();
+        _selectedIndex = 0;
     }
 
     private async Task SendMessage()

--- a/src/HotBox.Client/Components/Chat/MessageList.razor
+++ b/src/HotBox.Client/Components/Chat/MessageList.razor
@@ -1,6 +1,8 @@
 @using HotBox.Client.State
 @using HotBox.Client.Models
+@using System.Text.RegularExpressions
 @inject ChannelState ChannelState
+@inject AuthState AuthState
 @inject IJSRuntime JS
 @implements IDisposable
 
@@ -57,7 +59,7 @@
 
                 if (isNewAuthor)
                 {
-                    <div class="message-group new-author">
+                    <div class="message-group new-author @(ContainsMentionOfCurrentUser(msg.Content) ? "mentioned" : "")">
                         <div class="msg-avatar" style="background: @GetAvatarColor(msg.AuthorDisplayName);">
                             @GetInitials(msg.AuthorDisplayName)
                         </div>
@@ -76,16 +78,16 @@
                                 }
                                 <span class="msg-timestamp">@FormatTime(msg.CreatedAtUtc)</span>
                             </div>
-                            <div class="msg-body">@msg.Content</div>
+                            <div class="msg-body">@RenderMessageContent(msg.Content)</div>
                         </div>
                     </div>
                 }
                 else
                 {
-                    <div class="message-group">
+                    <div class="message-group @(ContainsMentionOfCurrentUser(msg.Content) ? "mentioned" : "")">
                         <div style="width: 34px; flex-shrink: 0;"></div>
                         <div class="msg-content">
-                            <div class="msg-body">@msg.Content</div>
+                            <div class="msg-body">@RenderMessageContent(msg.Content)</div>
                         </div>
                     </div>
                 }
@@ -218,6 +220,51 @@
     private void ClosePopover()
     {
         _selectedAuthorId = null;
+    }
+
+    private static readonly Regex MentionRegex = new(@"@\[([^\]]+)\]\(([0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12})\)", RegexOptions.Compiled);
+
+    private RenderFragment RenderMessageContent(string content) => builder =>
+    {
+        var lastIndex = 0;
+        var seq = 0;
+
+        foreach (Match match in MentionRegex.Matches(content))
+        {
+            if (match.Index > lastIndex)
+            {
+                builder.AddContent(seq++, content[lastIndex..match.Index]);
+            }
+
+            var displayName = match.Groups[1].Value;
+            var userId = match.Groups[2].Value;
+            var isSelf = AuthState.CurrentUser?.Id.ToString() == userId;
+
+            builder.OpenElement(seq++, "span");
+            builder.AddAttribute(seq++, "class", isSelf ? "mention mention-self" : "mention");
+            builder.AddContent(seq++, $"@{displayName}");
+            builder.CloseElement();
+
+            lastIndex = match.Index + match.Length;
+        }
+
+        if (lastIndex < content.Length)
+        {
+            builder.AddContent(seq++, content[lastIndex..]);
+        }
+    };
+
+    private bool ContainsMentionOfCurrentUser(string content)
+    {
+        var currentUserId = AuthState.CurrentUser?.Id.ToString();
+        if (currentUserId is null) return false;
+
+        foreach (Match match in MentionRegex.Matches(content))
+        {
+            if (match.Groups[2].Value == currentUserId)
+                return true;
+        }
+        return false;
     }
 
     public void Dispose()

--- a/src/HotBox.Client/wwwroot/css/app.css
+++ b/src/HotBox.Client/wwwroot/css/app.css
@@ -4362,3 +4362,89 @@ input, textarea {
   border: 1px solid var(--border-subtle);
   color: var(--accent-hover);
 }
+
+/* ========================================
+   @mention Autocomplete
+   ======================================== */
+.mention-autocomplete {
+  position: absolute;
+  bottom: 100%;
+  left: 0;
+  right: 0;
+  margin-bottom: 4px;
+  background: var(--bg-raised);
+  border: 1px solid var(--border-light);
+  border-radius: var(--radius-md);
+  padding: 4px 0;
+  max-height: 320px;
+  overflow-y: auto;
+  z-index: 100;
+  box-shadow: 0 -4px 16px rgba(0, 0, 0, 0.3);
+}
+
+.mention-autocomplete-item {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 8px 12px;
+  cursor: pointer;
+  color: var(--text-secondary);
+  font-size: 14px;
+  transition: background 0.1s ease;
+}
+
+.mention-autocomplete-item:hover,
+.mention-autocomplete-item.selected {
+  background: var(--bg-hover);
+  color: var(--text-primary);
+}
+
+.mention-autocomplete-item .mention-display-name {
+  flex: 1;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.mention-autocomplete-item .mention-badge {
+  font-size: 10px;
+  font-weight: 600;
+  letter-spacing: 0.5px;
+  padding: 2px 5px;
+  border-radius: var(--radius-xs);
+  background: var(--bot-badge-bg);
+  color: var(--bot-badge-color);
+  flex-shrink: 0;
+}
+
+/* ========================================
+   Mention Rendering (in message content)
+   ======================================== */
+.mention {
+  color: var(--accent);
+  background: var(--accent-muted);
+  border-radius: var(--radius-xs);
+  padding: 0 2px;
+  font-weight: 500;
+  transition: background var(--transition-fast);
+}
+
+.mention:hover {
+  background: rgba(93, 228, 199, 0.18);
+}
+
+.mention.mention-self {
+  color: var(--accent-strong);
+  background: rgba(93, 228, 199, 0.15);
+}
+
+/* Message group mentioned indicator */
+.message-group.mentioned {
+  background: rgba(93, 228, 199, 0.04);
+  border-left: 2px solid var(--accent);
+  padding-left: 6px;
+}
+
+.message-group.mentioned:hover {
+  background: rgba(93, 228, 199, 0.06);
+}


### PR DESCRIPTION
## Summary

- **Backend**: Replaced broken regex-based mention extraction (`@(\w+)` matching against email-based UserNames) with structured marker parsing (`@[DisplayName](userId)`). Backend now extracts GUIDs directly — eliminates case-sensitivity, false positives on emails, and display name matching issues
- **Autocomplete**: Added @mention autocomplete popup to both `MessageInput` and `DirectMessageInput` — type `@` to see a filterable member list, navigate with arrow keys, select with Enter/Tab, dismiss with Escape
- **Rendering**: Mentions render as highlighted teal spans in both `MessageList` and `DirectMessageMessageList`. Messages mentioning the current user get a left-border accent highlight
- **Tests**: Updated 4 existing tests to use new marker format, added 3 new negative tests (old @username format, emails, invalid GUIDs)
- **Accessibility**: Full ARIA support on autocomplete (role="listbox", aria-selected, aria-expanded, aria-controls)

Closes #194

## Follow-up

- #195 — Hide raw mention markers in the input box (show `@DisplayName` instead of `@[DisplayName](guid)`)
- Click-to-profile on rendered mentions (not yet wired up)

## Review Status

- Code review: 1 iteration — all Critical/Major issues resolved (stricter GUID regex, StateHasChanged, ARIA attributes)
- UI review: 1 iteration — all Critical/Major issues resolved (ARIA, cursor:pointer, badge consistency)
- All 33 tests pass

## Test plan

- [ ] Type `@` in channel message input — autocomplete popup appears with member list
- [ ] Filter by typing after `@` — list narrows to matching display names
- [ ] Arrow keys navigate, Enter/Tab selects, Escape dismisses
- [ ] Selected mention inserts `@[DisplayName](userId)` marker in input
- [ ] Sent message renders mention as highlighted teal span
- [ ] Messages mentioning current user have left-border accent highlight
- [ ] Plain `@username` text does NOT trigger mention notifications
- [ ] Email addresses in messages do NOT false-positive as mentions
- [ ] Works in both channel messages and direct messages
- [ ] Autocomplete works in DirectMessageInput as well

🤖 Generated with [Claude Code](https://claude.com/claude-code)