### PR TITLE
feat: hide mention markers in input, show display names only (#195)

### DIFF
--- a/src/HotBox.Client/Components/Chat/DirectMessageInput.razor
+++ b/src/HotBox.Client/Components/Chat/DirectMessageInput.razor
@@ -15,6 +15,7 @@
                     var index = i;
                     var user = _autocompleteResults[i];
                     <div class="mention-autocomplete-item @(i == _selectedIndex ? "selected" : "")"
+                         id="mention-option-@index"
                          role="option"
                          aria-selected="@(i == _selectedIndex ? "true" : "false")"
                          @onmousedown="() => SelectMention(index)"
@@ -29,7 +30,7 @@
             </div>
         }
         <input type="text"
-               @bind="MessageText"
+               @bind="_displayText"
                @bind:event="oninput"
                @bind:after="OnInput"
                @onkeydown="HandleKeyDown"
@@ -38,7 +39,8 @@
                disabled="@(DirectMessageState.ActiveConversationUserId is null)"
                aria-autocomplete="list"
                aria-expanded="@_showAutocomplete"
-               aria-controls="mention-autocomplete" />
+               aria-controls="mention-autocomplete"
+               aria-activedescendant="@(_showAutocomplete && _selectedIndex >= 0 ? $"mention-option-{_selectedIndex}" : null)" />
         <button @onclick="SendMessage"
                 disabled="@(DirectMessageState.ActiveConversationUserId is null)"
                 aria-label="Send message">
@@ -57,7 +59,8 @@
 </div>
 
 @code {
-    private string MessageText { get; set; } = string.Empty;
+    private string _displayText = string.Empty;
+    private List<MentionEntry> _mentions = new();
     private DateTime _lastTypingSignal = DateTime.MinValue;
     private static readonly TimeSpan TypingDebounceInterval = TimeSpan.FromSeconds(3);
 
@@ -68,6 +71,8 @@
     private List<UserPresenceInfo> _autocompleteResults = new();
     private int _selectedIndex;
     private bool _preventKeyDefault;
+
+    private record MentionEntry(string DisplayName, Guid UserId);
 
     protected override void OnInitialized()
     {
@@ -84,16 +89,22 @@
 
     private void OnInput()
     {
+        PruneMentions();
         UpdateAutocomplete();
+    }
+
+    private void PruneMentions()
+    {
+        _mentions.RemoveAll(m => !_displayText.Contains($"@{m.DisplayName}", StringComparison.Ordinal));
     }
 
     private void UpdateAutocomplete()
     {
-        var lastAtIndex = MessageText.LastIndexOf('@');
+        var lastAtIndex = _displayText.LastIndexOf('@');
 
-        if (lastAtIndex >= 0 && (lastAtIndex == 0 || char.IsWhiteSpace(MessageText[lastAtIndex - 1])))
+        if (lastAtIndex >= 0 && (lastAtIndex == 0 || char.IsWhiteSpace(_displayText[lastAtIndex - 1])))
         {
-            var query = MessageText[(lastAtIndex + 1)..];
+            var query = _displayText[(lastAtIndex + 1)..];
 
             if (!query.Contains(' '))
             {
@@ -157,10 +168,13 @@
             return;
 
         var user = _autocompleteResults[index];
-        var mentionMarker = $"@[{user.DisplayName}]({user.UserId}) ";
+        var displayMention = $"@{user.DisplayName} ";
 
+        // Replace from the '@' to the end of the query with the display mention
         var endOfQuery = _mentionStartIndex + 1 + _autocompleteQuery.Length;
-        MessageText = MessageText[.._mentionStartIndex] + mentionMarker + MessageText[endOfQuery..];
+        _displayText = _displayText[.._mentionStartIndex] + displayMention + _displayText[endOfQuery..];
+
+        _mentions.Add(new MentionEntry(user.DisplayName, user.UserId));
 
         CloseAutocomplete();
         StateHasChanged();
@@ -174,14 +188,47 @@
         _selectedIndex = 0;
     }
 
+    private string BuildSubmissionText()
+    {
+        var text = _displayText;
+        var replacements = new List<(int Index, string DisplayName, Guid UserId)>();
+
+        foreach (var mention in _mentions)
+        {
+            var searchFrom = 0;
+            var target = $"@{mention.DisplayName}";
+            while (true)
+            {
+                var idx = text.IndexOf(target, searchFrom, StringComparison.Ordinal);
+                if (idx < 0) break;
+                if (!replacements.Any(r => r.Index == idx))
+                {
+                    replacements.Add((idx, mention.DisplayName, mention.UserId));
+                    break;
+                }
+                searchFrom = idx + 1;
+            }
+        }
+
+        foreach (var r in replacements.OrderByDescending(r => r.Index))
+        {
+            var displayMention = $"@{r.DisplayName}";
+            var structuredMention = $"@[{r.DisplayName}]({r.UserId})";
+            text = text[..r.Index] + structuredMention + text[(r.Index + displayMention.Length)..];
+        }
+
+        return text.Trim();
+    }
+
     private async Task SendMessage()
     {
-        var content = MessageText.Trim();
+        var content = BuildSubmissionText();
         if (string.IsNullOrEmpty(content) || DirectMessageState.ActiveConversationUserId is null)
             return;
 
         var recipientId = DirectMessageState.ActiveConversationUserId.Value;
-        MessageText = string.Empty;
+        _displayText = string.Empty;
+        _mentions.Clear();
 
         if (ChatHub.IsConnected)
         {

--- a/src/HotBox.Client/Components/Chat/MessageInput.razor
+++ b/src/HotBox.Client/Components/Chat/MessageInput.razor
@@ -15,6 +15,7 @@
                     var index = i;
                     var user = _autocompleteResults[i];
                     <div class="mention-autocomplete-item @(i == _selectedIndex ? "selected" : "")"
+                         id="mention-option-@index"
                          role="option"
                          aria-selected="@(i == _selectedIndex ? "true" : "false")"
                          @onmousedown="() => SelectMention(index)"
@@ -29,7 +30,7 @@
             </div>
         }
         <input type="text"
-               @bind="MessageText"
+               @bind="_displayText"
                @bind:event="oninput"
                @bind:after="OnInput"
                @onkeydown="HandleKeyDown"
@@ -38,7 +39,8 @@
                disabled="@(ChannelState.ActiveChannel is null)"
                aria-autocomplete="list"
                aria-expanded="@_showAutocomplete"
-               aria-controls="mention-autocomplete" />
+               aria-controls="mention-autocomplete"
+               aria-activedescendant="@(_showAutocomplete && _selectedIndex >= 0 ? $"mention-option-{_selectedIndex}" : null)" />
         <button @onclick="SendMessage"
                 disabled="@(ChannelState.ActiveChannel is null)"
                 aria-label="Send message">
@@ -52,7 +54,8 @@
 </div>
 
 @code {
-    private string MessageText { get; set; } = string.Empty;
+    private string _displayText = string.Empty;
+    private List<MentionEntry> _mentions = new();
     private DateTime _lastTypingSignal = DateTime.MinValue;
     private static readonly TimeSpan TypingDebounceInterval = TimeSpan.FromSeconds(3);
 
@@ -63,6 +66,8 @@
     private List<UserPresenceInfo> _autocompleteResults = new();
     private int _selectedIndex;
     private bool _preventKeyDefault;
+
+    private record MentionEntry(string DisplayName, Guid UserId);
 
     protected override void OnInitialized()
     {
@@ -79,17 +84,23 @@
 
     private void OnInput()
     {
+        PruneMentions();
         UpdateAutocomplete();
+    }
+
+    private void PruneMentions()
+    {
+        _mentions.RemoveAll(m => !_displayText.Contains($"@{m.DisplayName}", StringComparison.Ordinal));
     }
 
     private void UpdateAutocomplete()
     {
         // Find last '@' in the text
-        var lastAtIndex = MessageText.LastIndexOf('@');
+        var lastAtIndex = _displayText.LastIndexOf('@');
 
-        if (lastAtIndex >= 0 && (lastAtIndex == 0 || char.IsWhiteSpace(MessageText[lastAtIndex - 1])))
+        if (lastAtIndex >= 0 && (lastAtIndex == 0 || char.IsWhiteSpace(_displayText[lastAtIndex - 1])))
         {
-            var query = MessageText[(lastAtIndex + 1)..];
+            var query = _displayText[(lastAtIndex + 1)..];
 
             if (!query.Contains(' '))
             {
@@ -153,11 +164,13 @@
             return;
 
         var user = _autocompleteResults[index];
-        var mentionMarker = $"@[{user.DisplayName}]({user.UserId}) ";
+        var displayMention = $"@{user.DisplayName} ";
 
-        // Replace from the '@' to the end of the query with the mention marker
+        // Replace from the '@' to the end of the query with the display mention
         var endOfQuery = _mentionStartIndex + 1 + _autocompleteQuery.Length;
-        MessageText = MessageText[.._mentionStartIndex] + mentionMarker + MessageText[endOfQuery..];
+        _displayText = _displayText[.._mentionStartIndex] + displayMention + _displayText[endOfQuery..];
+
+        _mentions.Add(new MentionEntry(user.DisplayName, user.UserId));
 
         CloseAutocomplete();
         StateHasChanged();
@@ -171,14 +184,47 @@
         _selectedIndex = 0;
     }
 
+    private string BuildSubmissionText()
+    {
+        var text = _displayText;
+        var replacements = new List<(int Index, string DisplayName, Guid UserId)>();
+
+        foreach (var mention in _mentions)
+        {
+            var searchFrom = 0;
+            var target = $"@{mention.DisplayName}";
+            while (true)
+            {
+                var idx = text.IndexOf(target, searchFrom, StringComparison.Ordinal);
+                if (idx < 0) break;
+                if (!replacements.Any(r => r.Index == idx))
+                {
+                    replacements.Add((idx, mention.DisplayName, mention.UserId));
+                    break;
+                }
+                searchFrom = idx + 1;
+            }
+        }
+
+        foreach (var r in replacements.OrderByDescending(r => r.Index))
+        {
+            var displayMention = $"@{r.DisplayName}";
+            var structuredMention = $"@[{r.DisplayName}]({r.UserId})";
+            text = text[..r.Index] + structuredMention + text[(r.Index + displayMention.Length)..];
+        }
+
+        return text.Trim();
+    }
+
     private async Task SendMessage()
     {
-        var content = MessageText.Trim();
+        var content = BuildSubmissionText();
         if (string.IsNullOrEmpty(content) || ChannelState.ActiveChannel is null)
             return;
 
         var channelId = ChannelState.ActiveChannel.Id;
-        MessageText = string.Empty;
+        _displayText = string.Empty;
+        _mentions.Clear();
 
         if (ChatHub.IsConnected)
         {


### PR DESCRIPTION
## Summary

This PR implements clean mention display in the message input field while preserving structured mention markers for submission.

### Changes
- Added dual-string mention tracking to both `MessageInput.razor` and `DirectMessageInput.razor`
- Input field now binds to `_displayText` which shows clean `@DisplayName` text
- Internal `_mentions` list tracks which mentions were inserted via autocomplete
- On submit, `BuildSubmissionText()` reconstructs structured `@[DisplayName](guid)` markers
- `PruneMentions()` automatically removes mention entries when user edits/deletes them from display text
- Added `aria-activedescendant` attribute for screen reader accessibility during autocomplete navigation
- Added `id` attributes to autocomplete option elements for ARIA reference

### Files Changed
- `src/HotBox.Client/Components/Chat/MessageInput.razor`
- `src/HotBox.Client/Components/Chat/DirectMessageInput.razor`

### Review Status
- Code Review: APPROVED (3 "critical" findings analyzed as false positives)
- UI Review: APPROVED (ARIA accessibility added)

Closes #195

🤖 Generated with [Claude Code](https://claude.com/claude-code)