### PR TITLE
fix: show all registered users in members panel (#198)

### DIFF
--- a/src/HotBox.Client/Layout/MainLayout.razor
+++ b/src/HotBox.Client/Layout/MainLayout.razor
@@ -293,10 +293,26 @@
         PresenceState.SetOnlineUsers(users);
     }
 
-    private void HandleConnectionChanged(bool connected)
+    private async void HandleConnectionChanged(bool connected)
     {
         if (connected)
         {
+            // Seed all registered users as Offline so they appear in the members panel
+            // even if they have never connected via SignalR. The subsequent OnOnlineUsers
+            // event will overlay actual online statuses on top.
+            try
+            {
+                var allUsers = await Api.GetAllUsersAsync();
+                if (allUsers is not null)
+                {
+                    PresenceState.SeedAllUsers(allUsers);
+                }
+            }
+            catch (Exception ex)
+            {
+                Logger.LogError(ex, "Failed to seed all users for presence state");
+            }
+
             // Start heartbeat timer when connected (fires every 60 seconds)
             _heartbeatTimer?.Dispose();
             _heartbeatTimer = new System.Threading.Timer(

--- a/src/HotBox.Client/Services/ApiClient.cs
+++ b/src/HotBox.Client/Services/ApiClient.cs
@@ -272,6 +272,11 @@ public class ApiClient
 
     // ── Users ──────────────────────────────────────────────────────────────
 
+    public async Task<List<UserProfileResponse>> GetAllUsersAsync(CancellationToken ct = default)
+    {
+        return await GetAsync<List<UserProfileResponse>>("api/users", ct) ?? new List<UserProfileResponse>();
+    }
+
     public async Task<List<UserSearchResult>> SearchUsersAsync(string? query = null, CancellationToken ct = default)
     {
         var url = "api/users/search";

--- a/src/HotBox.Client/wwwroot/css/app.css
+++ b/src/HotBox.Client/wwwroot/css/app.css
@@ -685,7 +685,7 @@ input, textarea {
 
 .member-item.offline .member-avatar,
 .member-item.offline .member-name {
-  opacity: 0.35;
+  opacity: 0.55;
 }
 
 /* Settings button in topbar */


### PR DESCRIPTION
## Summary

The Members panel previously only showed users who had connected via SignalR since the last server restart. This fix implements a client-side merge approach where all registered users are fetched from the API and seeded as "Offline" in PresenceState when SignalR connects. Real-time presence updates from SignalR then overlay actual online statuses on top of the seeded users.

## Changes

### PresenceState
- Added `SeedAllUsers` method that populates all DB users as Offline without overwriting existing entries
- Changed `SetOnlineUsers` to update in-place (mark all Offline, then overlay online) instead of clearing and rebuilding
- Individual `UserStatusChanged` events continue to update statuses in real-time

### ApiClient
- Added `GetAllUsersAsync` method to fetch all users from the existing `GET /api/users` endpoint

### MainLayout
- Updated `HandleConnectionChanged` to fetch and seed all users when SignalR connects

### CSS
- Improved offline user visibility (opacity 0.55) for WCAG AA accessibility compliance

## Files Changed
- src/HotBox.Client/State/PresenceState.cs
- src/HotBox.Client/Services/ApiClient.cs
- src/HotBox.Client/Layout/MainLayout.razor
- src/HotBox.Client/wwwroot/css/app.css

## Review Status
- Code Review: NEEDS_CHANGES → fixes applied (1 iteration)
- UI Review: NEEDS_CHANGES → fixes applied (1 iteration)
- Review iterations: 1
- Unresolved items: none

Closes #198

Generated with [Claude Code](https://claude.com/claude-code)