### PR TITLE
perf: parallelize init, fix channel flash, deduplicate DM load

### DIFF
--- a/src/HotBox.Client/Components/Chat/DirectMessageList.razor
+++ b/src/HotBox.Client/Components/Chat/DirectMessageList.razor
@@ -53,7 +53,7 @@
         DirectMessageState.OnChange += StateHasChanged;
         UnreadState.OnChange += StateHasChanged;
 
-        if (!_loaded)
+        if (!_loaded && DirectMessageState.Conversations.Count == 0)
         {
             _loaded = true;
             var conversations = await Api.GetConversationsAsync();

--- a/src/HotBox.Client/Layout/MainLayout.razor
+++ b/src/HotBox.Client/Layout/MainLayout.razor
@@ -281,16 +281,12 @@
         // Start the SignalR hub connection so we receive presence and real-time events
         if (AuthState.AccessToken is not null)
         {
-            await ChatHubService.StartAsync(AuthState.AccessToken);
-
-            // Initialize the voice connection manager with the current access token
-            await VoiceConnectionManager.InitializeAsync(AuthState.AccessToken);
-
-            // Load initial unread counts
-            await UnreadState.InitializeAsync();
-
-            // Load initial notification unread count
-            await NotificationState.InitializeAsync();
+            await Task.WhenAll(
+                ChatHubService.StartAsync(AuthState.AccessToken),
+                VoiceConnectionManager.InitializeAsync(AuthState.AccessToken),
+                UnreadState.InitializeAsync(),
+                NotificationState.InitializeAsync()
+            );
         }
 
         // Heartbeat timer is started/stopped via HandleConnectionChanged

--- a/src/HotBox.Client/Pages/ChannelPage.razor
+++ b/src/HotBox.Client/Pages/ChannelPage.razor
@@ -62,7 +62,11 @@
 
         _currentChannelId = Id;
 
-        // Set active channel from the already-loaded channel list
+        // Set loading FIRST so the skeleton shows during the channel switch
+        ChannelState.SetLoadingMessages(true);
+        ChannelState.SetHasMoreMessages(true);
+
+        // Now set active channel (clears messages, but skeleton is already showing)
         var channel = ChannelState.Channels.FirstOrDefault(c => c.Id == Id);
         if (channel is not null)
         {
@@ -77,10 +81,6 @@
                 ChannelState.SetActiveChannel(fetched);
             }
         }
-
-        // Load messages for this channel
-        ChannelState.SetLoadingMessages(true);
-        ChannelState.SetHasMoreMessages(true);
         try
         {
             List<MessageResponse> messages;


### PR DESCRIPTION
## Summary
- **Parallel initialization**: MainLayout now runs ChatHub, VoiceConnection, UnreadState, and NotificationState init concurrently via `Task.WhenAll` instead of sequentially, reducing startup time
- **Fix channel switch flash**: ChannelPage sets the loading flag *before* `SetActiveChannel` so the skeleton loader is visible immediately, eliminating a one-frame flash of empty content
- **Deduplicate DM conversations load**: DirectMessageList skips the API call when conversations are already in state, preventing a duplicate `GetConversationsAsync` when both DirectMessageList and DmsPage mount

## Test plan
- [ ] Login and verify faster initial load (parallel init — no functional change)
- [ ] Switch between channels and confirm skeleton appears instantly with no empty flash
- [ ] Switch to DMs → Channels → DMs and verify only one `GetConversationsAsync` call in browser network tab
- [ ] `dotnet build src/HotBox.Client` passes with no errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)