### PR TITLE
fix: clicking same channel link empties message list

### DIFF
--- a/src/HotBox.Client/Components/Chat/ChannelList.razor
+++ b/src/HotBox.Client/Components/Chat/ChannelList.razor
@@ -51,6 +51,9 @@ else
 
     private void SelectChannel(ChannelResponse channel)
     {
+        if (ChannelState.ActiveChannel?.Id == channel.Id)
+            return;
+
         ChannelState.SetActiveChannel(channel);
         Navigation.NavigateTo($"/channels/{channel.Id}");
     }


### PR DESCRIPTION
## Summary
- Add early return in `ChannelList.SelectChannel()` when the clicked channel is already active
- Prevents `SetActiveChannel()` from clearing the message list when re-selecting the current channel
- Blazor's router skipped the refetch since parameters were unchanged, leaving the list empty

Closes #206

## Test plan
- [ ] Navigate to a channel (e.g. #general) and verify messages load
- [ ] Click the same channel link again — messages should remain visible
- [ ] Switch to a different channel and back — should still work normally
- [ ] Verify active channel styling still applies correctly in the sidebar

🤖 Generated with [Claude Code](https://claude.com/claude-code)