### PR TITLE
fix: populate last message content and add avatars on DMs page

### DIFF
--- a/src/HotBox.Application/Controllers/DirectMessagesController.cs
+++ b/src/HotBox.Application/Controllers/DirectMessagesController.cs
@@ -43,7 +43,7 @@ public class DirectMessagesController : ControllerBase
         {
             UserId = c.UserId,
             DisplayName = c.DisplayName,
-            LastMessageContent = string.Empty,
+            LastMessageContent = c.LastMessageContent,
             LastMessageAtUtc = c.LastMessageAtUtc,
             UnreadCount = unreadCounts.GetValueOrDefault(c.UserId, 0),
         }).ToList();

--- a/src/HotBox.Client/Pages/DmsPage.razor
+++ b/src/HotBox.Client/Pages/DmsPage.razor
@@ -31,6 +31,9 @@ else
             @foreach (var conversation in DirectMessageState.Conversations)
             {
                 <button class="dms-page-item" @onclick="() => SelectConversation(conversation)">
+                    <div class="dms-page-item-avatar" style="background: @GetAvatarColor(conversation.DisplayName);">
+                        @GetInitials(conversation.DisplayName)
+                    </div>
                     <div class="dms-page-item-main">
                         <div class="dms-page-item-name">@conversation.DisplayName</div>
                         <div class="dms-page-item-preview">@(string.IsNullOrWhiteSpace(conversation.LastMessageContent) ? "No messages yet" : conversation.LastMessageContent)</div>
@@ -96,6 +99,27 @@ else
             return $"{(int)diff.TotalDays}d ago";
 
         return local.ToString("MMM d");
+    }
+
+    private static string GetAvatarColor(string name)
+    {
+        int hash = 0;
+        foreach (char c in name)
+        {
+            hash = c + ((hash << 5) - hash);
+        }
+        int hue = Math.Abs(hash) % 360;
+        return $"hsl({hue}, 32%, 38%)";
+    }
+
+    private static string GetInitials(string displayName)
+    {
+        var parts = displayName.Split(' ', StringSplitOptions.RemoveEmptyEntries);
+        if (parts.Length >= 2)
+            return $"{parts[0][0]}{parts[1][0]}".ToUpper();
+        return displayName.Length >= 2
+            ? displayName[..2].ToUpper()
+            : displayName.ToUpper();
     }
 
     public void Dispose()

--- a/src/HotBox.Client/wwwroot/css/app.css
+++ b/src/HotBox.Client/wwwroot/css/app.css
@@ -1665,6 +1665,19 @@ input, textarea {
   background: var(--bg-hover);
 }
 
+.dms-page-item-avatar {
+  width: 36px;
+  height: 36px;
+  border-radius: var(--r-pill);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 13px;
+  font-weight: 600;
+  color: #fff;
+  flex-shrink: 0;
+}
+
 .dms-page-item-main {
   display: flex;
   flex-direction: column;

--- a/src/HotBox.Core/Models/ConversationSummary.cs
+++ b/src/HotBox.Core/Models/ConversationSummary.cs
@@ -1,3 +1,3 @@
 namespace HotBox.Core.Models;
 
-public record ConversationSummary(Guid UserId, string DisplayName, DateTime LastMessageAtUtc);
+public record ConversationSummary(Guid UserId, string DisplayName, DateTime LastMessageAtUtc, string LastMessageContent);

--- a/src/HotBox.Infrastructure/Repositories/DirectMessageRepository.cs
+++ b/src/HotBox.Infrastructure/Repositories/DirectMessageRepository.cs
@@ -53,13 +53,15 @@ public class DirectMessageRepository : IDirectMessageRepository
             .Select(dm => new
             {
                 OtherUserId = dm.SenderId == userId ? dm.RecipientId : dm.SenderId,
-                dm.CreatedAtUtc
+                dm.CreatedAtUtc,
+                dm.Content
             })
             .GroupBy(x => x.OtherUserId)
             .Select(g => new
             {
                 UserId = g.Key,
-                LastMessageAtUtc = g.Max(x => x.CreatedAtUtc)
+                LastMessageAtUtc = g.Max(x => x.CreatedAtUtc),
+                LastMessageContent = g.OrderByDescending(x => x.CreatedAtUtc).First().Content
             })
             .Join(
                 _context.Users,
@@ -68,7 +70,8 @@ public class DirectMessageRepository : IDirectMessageRepository
                 (dm, u) => new ConversationSummary(
                     dm.UserId,
                     u.DisplayName,
-                    dm.LastMessageAtUtc))
+                    dm.LastMessageAtUtc,
+                    dm.LastMessageContent))
             .OrderByDescending(c => c.LastMessageAtUtc)
             .ToListAsync(ct);
     }


### PR DESCRIPTION
## Summary
- **Backend**: Updated `GetConversationsAsync` repository query to fetch the latest message content per conversation via `GroupBy` + `OrderByDescending().First()`
- **Controller**: Wired `LastMessageContent` from the domain model instead of hardcoding `string.Empty`
- **Client**: Added colored-initial avatars to the `/dms` conversation list, matching the existing chat message avatar pattern

Closes #207

## Test plan
- [ ] Navigate to `/dms` and verify conversations show last message preview text
- [ ] Verify each conversation item displays a colored-initial avatar
- [ ] Send a new DM and verify the conversation list updates with the new message content
- [ ] Verify the "No messages yet" fallback still shows when content is empty

🤖 Generated with [Claude Code](https://claude.com/claude-code)